### PR TITLE
CMake test targets are now marked EXCLUDE_FROM_ALL

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -220,7 +220,7 @@ def linux_cmake_nointeg(name):
                 '--source-dir=$(pwd) ' + \
                 'cmake-nointeg ' + \
                 '--generator=Ninja '
-    return _pipeline(name=name, image=_image('build-clang18'), os='linux', command=command, db=None)
+    return _pipeline(name=name, image=_image('build-gcc13'), os='linux', command=command, db=None)
 
 
 def windows_cmake(

--- a/.drone.star
+++ b/.drone.star
@@ -215,6 +215,14 @@ def linux_cmake_noopenssl(name):
     return _pipeline(name=name, image=_image('build-noopenssl'), os='linux', command=command, db=None)
 
 
+def linux_cmake_nointeg(name):
+    command = 'python tools/ci/main.py ' + \
+                '--source-dir=$(pwd) ' + \
+                'cmake-nointeg ' + \
+                '--generator=Ninja '
+    return _pipeline(name=name, image=_image('build-clang18'), os='linux', command=command, db=None)
+
+
 def windows_cmake(
     name,
     build_shared_libs=0

--- a/.drone.star
+++ b/.drone.star
@@ -272,6 +272,7 @@ def main(ctx):
         linux_cmake('Linux CMake gcc Release',    _image('build-gcc11'), cmake_build_type='Release'),
         linux_cmake('Linux CMake gcc MinSizeRel', _image('build-gcc13'), cmake_build_type='MinSizeRel'),
         linux_cmake_noopenssl('Linux CMake no OpenSSL'),
+        linux_cmake_nointeg('Linux CMake without integration tests'),
 
         # CMake Windows
         windows_cmake('Windows CMake static', build_shared_libs=0),

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -16,3 +16,5 @@ target_link_libraries(
     PUBLIC
     boost_mysql_compiled
 )
+
+boost_mysql_common_target_settings(boost_mysql_bench_connection_pool)

--- a/cmake/test_utils.cmake
+++ b/cmake/test_utils.cmake
@@ -47,4 +47,9 @@ function(boost_mysql_common_target_settings TARGET_NAME)
     endif()
 
     set_target_properties(${TARGET_NAME} PROPERTIES CXX_EXTENSIONS OFF) # disable extensions
+
+    # Follow the Boost convention: don't build test targets by default,
+    # and only when explicitly requested by building target tests
+    set_target_properties(${TARGET_NAME} PROPERTIES EXCLUDE_FROM_ALL ON)
+    add_dependencies(tests ${TARGET_NAME})
 endfunction()

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -140,4 +140,3 @@ add_test(
     NAME boost_mysql_unittests
     COMMAND boost_mysql_unittests
 )
-add_dependencies(tests boost_mysql_unittests)

--- a/tools/ci/ci_util/cmake.py
+++ b/tools/ci/ci_util/cmake.py
@@ -98,22 +98,13 @@ def cmake_build(
             'CMAKE_INSTALL_PREFIX': str(cmake_distro),
             'BUILD_TESTING': 'ON',
             'CMAKE_INSTALL_MESSAGE': 'NEVER',
-            'BOOST_MYSQL_INTEGRATION_TESTS': 'OFF', # Explicitly state this to make rebuilds work
+            'BOOST_MYSQL_INTEGRATION_TESTS': 'ON',
             **({ 'CMAKE_CXX_STANDARD': cxxstd } if cxxstd else {})
         }
     )
     runner.build(target='tests')
     runner.ctest()
     runner.build(target='install')
-
-    # Step 2
-    runner.configure(
-        source_dir=BOOST_ROOT,
-        binary_dir=bin_dir,
-        variables={'BOOST_MYSQL_INTEGRATION_TESTS': 'ON'}
-    )
-    runner.build_all()
-    runner.ctest()
 
     # The library can be consumed using add_subdirectory
     runner.configure(

--- a/tools/ci/ci_util/cmake.py
+++ b/tools/ci/ci_util/cmake.py
@@ -168,6 +168,37 @@ def cmake_noopenssl_build(
     runner.build(target='install')
 
 
+# Check that disabling integration tests works
+def cmake_nointeg_build(
+    source_dir: Path,
+    boost_branch: str,
+    generator: str
+):
+    # Config
+    runner = _CMakeRunner(generator=generator, build_type='Release')
+
+    # Get Boost
+    install_boost(
+        source_dir=source_dir,
+        boost_branch=boost_branch,
+    )
+
+    # Build the library and run the tests, as the Boost superproject does
+    bin_dir = BOOST_ROOT.joinpath('__build')
+    runner.configure(
+        source_dir=BOOST_ROOT,
+        binary_dir=bin_dir,
+        variables={
+            'CMAKE_PREFIX_PATH': _cmake_prefix_path(),
+            'BOOST_INCLUDE_LIBRARIES': 'mysql',
+            'BUILD_TESTING': 'ON'
+        }
+    )
+    runner.build(target='tests')
+    runner.ctest()
+    runner.build(target='install')
+
+
 # Check that CMake can consume a Boost distribution created by b2
 def find_package_b2_test(
     source_dir: Path,

--- a/tools/ci/ci_util/main.py
+++ b/tools/ci/ci_util/main.py
@@ -11,7 +11,7 @@ from typing import Union
 import os
 import argparse
 from .common import IS_WINDOWS, BOOST_ROOT
-from .cmake import cmake_build, cmake_noopenssl_build, find_package_b2_test
+from .cmake import cmake_build, cmake_noopenssl_build, cmake_nointeg_build, find_package_b2_test
 from .b2 import b2_build
 from .docs import docs_build
 
@@ -103,6 +103,11 @@ def main():
     subp = subparsers.add_parser('cmake-noopenssl', help='CMake build without OpenSSL')
     subp.add_argument('--generator', default='Ninja')
     subp.set_defaults(func=cmake_noopenssl_build)
+
+    # cmake without integratin tests
+    subp = subparsers.add_parser('cmake-nointeg', help='CMake build without integration tests')
+    subp.add_argument('--generator', default='Ninja')
+    subp.set_defaults(func=cmake_nointeg_build)
 
     # find_package with b2 distribution
     subp = subparsers.add_parser('find-package-b2', help='find_package with b2 distribution test')


### PR DESCRIPTION
All test targets (including integration tests) are now only built when the `tests` target is built.
Added a CMake build that doesn't run integration testing (verifying that BOOST_MYSQL_INTEGRATION_TESTS works)

close #261 