### PR TITLE
Added formattable_ref

### DIFF
--- a/doc/qbk/22_sql_formatting.qbk
+++ b/doc/qbk/22_sql_formatting.qbk
@@ -426,6 +426,19 @@ Both client-side SQL formatting and prepared statements have pros and cons effic
         ]
         []
     ]
+    [
+        [[reflink formattable_ref]]
+        [
+            Formats the underlying value. Can represent any of the types above.[br]
+            Accepts the same format specifiers as the underlying type.
+        ]
+        [
+            ```
+            format_sql(opts, "SELECT {}", formattable_ref(42)) == "SELECT 42"
+            format_sql(opts, "SELECT * FROM {:i}", formattable_ref("employee")) == "SELECT * FROM `employee`"
+            ```
+        ]
+    ]
 ]
 
 [endsect]

--- a/doc/qbk/22_sql_formatting.qbk
+++ b/doc/qbk/22_sql_formatting.qbk
@@ -433,10 +433,7 @@ Both client-side SQL formatting and prepared statements have pros and cons effic
             Accepts the same format specifiers as the underlying type.
         ]
         [
-            ```
-            format_sql(opts, "SELECT {}", formattable_ref(42)) == "SELECT 42"
-            format_sql(opts, "SELECT * FROM {:i}", formattable_ref("employee")) == "SELECT * FROM `employee`"
-            ```
+            [sql_formatting_reference_formattable_ref]
         ]
     ]
 ]

--- a/doc/qbk/helpers/Formattable.qbk
+++ b/doc/qbk/helpers/Formattable.qbk
@@ -23,6 +23,7 @@ Formally, let `T` be any type, and `U` the result of stripping cv-qualifiers and
       type or have a custom formatted defined, but must not be a range.
     * `U` does not satisfy [reflink2 WritableFieldTuple WritableField] (i.e. `vector<unsigned char>` is
         formatted as a blob, not as a sequence).
+* `U` is [reflink formattable_ref].
 
 For a reference table on built-in formattable types, see [link mysql.sql_formatting.reference this section].
 

--- a/doc/qbk/helpers/quickref.xml
+++ b/doc/qbk/helpers/quickref.xml
@@ -41,6 +41,7 @@
           <member><link linkend="mysql.ref.boost__mysql__field_view">field_view</link></member>
           <member><link linkend="mysql.ref.boost__mysql__format_arg">format_arg</link></member>
           <member><link linkend="mysql.ref.boost__mysql__format_context_base">format_context_base</link></member>
+          <member><link linkend="mysql.ref.boost__mysql__formattable_ref">formattable_ref</link></member>
           <member><link linkend="mysql.ref.boost__mysql__formatter">formatter</link></member>
           <member><link linkend="mysql.ref.boost__mysql__format_options">format_options</link></member>
           <member><link linkend="mysql.ref.boost__mysql__format_sequence_view">format_sequence_view</link></member>

--- a/example/batch_inserts_generic.cpp
+++ b/example/batch_inserts_generic.cpp
@@ -101,7 +101,7 @@ struct insert_struct_format_fn
     void operator()(const T& value, boost::mysql::format_context_base& ctx) const
     {
         // Convert the struct into a std::array of formattable_ref
-        // formattable_ref is a view type that can hold anything that can be formatted
+        // formattable_ref is a view type that can hold any type that can be formatted
         auto args = mp11::tuple_apply(
             [&value](auto... descriptors) {
                 return std::array<boost::mysql::formattable_ref, num_public_members<T>>{

--- a/example/batch_inserts_generic.cpp
+++ b/example/batch_inserts_generic.cpp
@@ -100,12 +100,12 @@ struct insert_struct_format_fn
     template <class T>
     void operator()(const T& value, boost::mysql::format_context_base& ctx) const
     {
-        // Convert the struct into a std::array of field_view's
-        // TODO: this doesn't work for optionals or things with custom formatters
+        // Convert the struct into a std::array of formattable_ref
+        // formattable_ref is a view type that can hold anything that can be formatted
         auto args = mp11::tuple_apply(
             [&value](auto... descriptors) {
-                return std::array<boost::mysql::field_view, num_public_members<T>>{
-                    {boost::mysql::field_view(value.*descriptors.pointer)...}
+                return std::array<boost::mysql::formattable_ref, num_public_members<T>>{
+                    {value.*descriptors.pointer...}
                 };
             },
             mp11::mp_rename<public_members<T>, std::tuple>()

--- a/include/boost/mysql/detail/format_sql.hpp
+++ b/include/boost/mysql/detail/format_sql.hpp
@@ -8,15 +8,12 @@
 #ifndef BOOST_MYSQL_DETAIL_FORMAT_SQL_HPP
 #define BOOST_MYSQL_DETAIL_FORMAT_SQL_HPP
 
-#include <boost/mysql/error_code.hpp>
 #include <boost/mysql/field_view.hpp>
 #include <boost/mysql/string_view.hpp>
 
 #include <boost/mysql/detail/writable_field_traits.hpp>
 
-#include <initializer_list>
 #include <iterator>
-#include <string>
 #include <type_traits>
 #include <utility>
 
@@ -32,8 +29,6 @@ template <class T>
 struct formatter;
 
 class format_context_base;
-class format_arg;
-struct format_options;
 class formattable_ref;
 
 namespace detail {
@@ -160,16 +155,6 @@ struct formattable_ref_impl
 
 template <class T>
 formattable_ref_impl make_formattable_ref(T&& v);
-
-BOOST_MYSQL_DECL
-void vformat_sql_to(format_context_base& ctx, string_view format_str, std::initializer_list<format_arg> args);
-
-BOOST_MYSQL_DECL
-std::string vformat_sql(
-    const format_options& opts,
-    string_view format_str,
-    std::initializer_list<format_arg> args
-);
 
 }  // namespace detail
 }  // namespace mysql

--- a/include/boost/mysql/detail/format_sql.hpp
+++ b/include/boost/mysql/detail/format_sql.hpp
@@ -153,6 +153,7 @@ struct formattable_ref_impl
     data_t data;
 };
 
+// Create a type-erased formattable_ref_impl from a formattable value
 template <class T>
 formattable_ref_impl make_formattable_ref(T&& v);
 

--- a/include/boost/mysql/format_sql.hpp
+++ b/include/boost/mysql/format_sql.hpp
@@ -125,7 +125,7 @@ class format_arg
     struct
     {
         string_view name;
-        formattable_ref value;
+        detail::formattable_ref_impl value;
     } impl_;
 
     friend struct detail::access;
@@ -144,7 +144,10 @@ public:
      * \par Object lifetimes
      * Both `name` and `value` are stored as views.
      */
-    format_arg(string_view name, formattable_ref value) noexcept : impl_{name, value} {}
+    format_arg(string_view name, formattable_ref value) noexcept
+        : impl_{name, detail::access::get_impl(value)}
+    {
+    }
 };
 
 /**
@@ -228,8 +231,6 @@ public:
      * value is formatted according to its type, applying the passed format specifiers.
      * If formatting generates an error (for instance, a string with invalid encoding is passed),
      * the error state may be set.
-     * \n
-     * The supplied type must satisfy the `Formattable` concept.
      * \n
      * This is a low level function. In general, prefer \ref format_sql_to, instead.
      *

--- a/include/boost/mysql/format_sql.hpp
+++ b/include/boost/mysql/format_sql.hpp
@@ -529,14 +529,7 @@ struct formatter<format_sequence_view<It, Sentinel, FormatFn>>
  *     in `args` (there aren't enough arguments or a named argument is not found).
  */
 template <BOOST_MYSQL_FORMATTABLE... Formattable>
-void format_sql_to(format_context_base& ctx, constant_string_view format_str, Formattable&&... args)
-{
-    std::initializer_list<format_arg> args_il{
-        {string_view(), std::forward<Formattable>(args)}
-        ...
-    };
-    detail::vformat_sql_to(ctx, format_str.get(), args_il);
-}
+void format_sql_to(format_context_base& ctx, constant_string_view format_str, Formattable&&... args);
 
 /**
  * \copydoc format_sql_to
@@ -544,14 +537,12 @@ void format_sql_to(format_context_base& ctx, constant_string_view format_str, Fo
  * \n
  * This overload allows using named arguments.
  */
-inline void format_sql_to(
+BOOST_MYSQL_DECL
+void format_sql_to(
     format_context_base& ctx,
     constant_string_view format_str,
     std::initializer_list<format_arg> args
-)
-{
-    detail::vformat_sql_to(ctx, format_str.get(), args);
-}
+);
 
 /**
  * \brief (EXPERIMENTAL) Composes a SQL query client-side.
@@ -586,14 +577,7 @@ inline void format_sql_to(
  *     in `args` (there aren't enough arguments or a named argument is not found).
  */
 template <BOOST_MYSQL_FORMATTABLE... Formattable>
-std::string format_sql(const format_options& opts, constant_string_view format_str, Formattable&&... args)
-{
-    std::initializer_list<format_arg> args_il{
-        {string_view(), std::forward<Formattable>(args)}
-        ...
-    };
-    return detail::vformat_sql(opts, format_str.get(), args_il);
-}
+std::string format_sql(format_options opts, constant_string_view format_str, Formattable&&... args);
 
 /**
  * \copydoc format_sql
@@ -601,14 +585,12 @@ std::string format_sql(const format_options& opts, constant_string_view format_s
  * \n
  * This overload allows using named arguments.
  */
-inline std::string format_sql(
-    const format_options& opts,
+BOOST_MYSQL_DECL
+std::string format_sql(
+    format_options opts,
     constant_string_view format_str,
     std::initializer_list<format_arg> args
-)
-{
-    return detail::vformat_sql(opts, format_str.get(), args);
-}
+);
 
 }  // namespace mysql
 }  // namespace boost

--- a/include/boost/mysql/format_sql.hpp
+++ b/include/boost/mysql/format_sql.hpp
@@ -111,7 +111,7 @@ public:
      * `Formattable` type.
      * \n
      * This constructor participates in overload resolution only if
-     * the passed value meets the `Formattable` type requirements and
+     * the passed value meets the `Formattable` concept and
      * is not a `formattable_ref` or a reference to one.
      *
      * \par Exception safety

--- a/include/boost/mysql/format_sql.hpp
+++ b/include/boost/mysql/format_sql.hpp
@@ -86,7 +86,17 @@ struct formatter
 #endif
 ;
 
-// TODO: document
+/**
+ * \brief (EXPERIMENTAL) A type-erased reference to a `Formattable` value.
+ * \details
+ * This type can hold references to any value that satisfies the `Formattable`
+ * concept. The `formattable_ref` type itself satisfies `Formattable`,
+ * and can thus be used as an argument to format functions.
+ *
+ * \par Object lifetimes
+ * This is a non-owning type. It should be only used as a function argument,
+ * to avoid lifetime issues.
+ */
 class formattable_ref
 {
     detail::formattable_ref_impl impl_;
@@ -94,6 +104,23 @@ class formattable_ref
     friend struct detail::access;
 #endif
 public:
+    /**
+     * \brief Constructor.
+     * \details
+     * Constructs a type-erased formattable reference from a concrete
+     * `Formattable` type.
+     * \n
+     * This constructor participates in overload resolution only if
+     * the passed value meets the `Formattable` type requirements and
+     * is not a `formattable_ref` or a reference to one.
+     *
+     * \par Exception safety
+     * No-throw guarantee.
+     *
+     * \par Object lifetimes
+     * value is potentially stored as a view, although some cheap-to-copy
+     * types may be stored as values.
+     */
     template <
         BOOST_MYSQL_FORMATTABLE Formattable
 #ifndef BOOST_MYSQL_DOXYGEN

--- a/include/boost/mysql/format_sql.hpp
+++ b/include/boost/mysql/format_sql.hpp
@@ -136,7 +136,6 @@ public:
      * \brief Constructor.
      * \details
      * Constructs an argument from a name and a value.
-     * value must satisfy the `Formattable` concept.
      *
      * \par Exception safety
      * No-throw guarantee.

--- a/include/boost/mysql/impl/format_sql.hpp
+++ b/include/boost/mysql/impl/format_sql.hpp
@@ -1,0 +1,150 @@
+//
+// Copyright (c) 2019-2024 Ruben Perez Hidalgo (rubenperez038 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_MYSQL_IMPL_FORMAT_SQL_HPP
+#define BOOST_MYSQL_IMPL_FORMAT_SQL_HPP
+
+#pragma once
+
+#include <boost/mysql/format_sql.hpp>
+
+#include <type_traits>
+
+namespace boost {
+namespace mysql {
+namespace detail {
+
+BOOST_MYSQL_DECL
+std::pair<bool, string_view> parse_range_specifiers(const char* spec_begin, const char* spec_end);
+
+// To use with arguments with a custom formatter
+template <class T>
+bool do_format_custom_formatter(
+    const void* obj,
+    const char* spec_begin,
+    const char* spec_end,
+    format_context_base& ctx
+)
+{
+    formatter<T> fmt;
+    const char* it = fmt.parse(spec_begin, spec_end);
+    if (it != spec_end)
+    {
+        return false;
+    }
+    fmt.format(*static_cast<const T*>(obj), ctx);
+    return true;
+}
+
+// To use with ranges
+template <class T>
+bool do_format_range(const void* obj, const char* spec_begin, const char* spec_end, format_context_base& ctx)
+{
+    // Parse specifiers
+    auto res = detail::parse_range_specifiers(spec_begin, spec_end);
+    if (!res.first)
+        return false;
+    auto spec = runtime(res.second);
+
+    // Retrieve the object. T here may be the actual type U or const U
+    auto& value = *const_cast<T*>(static_cast<const T*>(obj));
+
+    // Output the sequence
+    bool is_first = true;
+    for (auto it = std::begin(value); it != std::end(value); ++it)
+    {
+        if (!is_first)
+            ctx.append_raw(", ");
+        is_first = false;
+        ctx.append_value(*it, spec);
+    }
+    return true;
+}
+
+// make_format_value: creates a type erased format_arg_value from a typed value.
+// Used for types having is_writable_field<T>
+template <class T, bool is_rng>
+formattable_ref_impl make_format_value_impl(
+    const T& v,
+    std::true_type,                        // is_writable_field
+    std::integral_constant<bool, is_rng>,  // is formattable range: we don't care
+    std::false_type                        // is formattable ref
+)
+{
+    // Only string types (and not field_views or optionals) support the string specifiers
+    return {
+        std::is_convertible<T, string_view>::value ? formattable_ref_impl::type_t::field_with_specs
+                                                   : formattable_ref_impl::type_t::field,
+        to_field(v)
+    };
+}
+
+// Used for types having is_formattable_range
+template <class T>
+formattable_ref_impl make_format_value_impl(
+    T&& v,
+    std::false_type,  // writable field
+    std::true_type,   // is formattable range
+    std::false_type   // is formattable ref
+)
+{
+    // Although everything is passed as const void*, do_format_range
+    // can bypass const-ness for non-const ranges (e.g. filter_view)
+    return {
+        formattable_ref_impl::type_t::fn_and_ptr,
+        formattable_ref_impl::fn_and_ptr{&v, &do_format_range<typename std::remove_reference<T>::type>}
+    };
+}
+
+// Used for types having !is_writable_field<T>
+template <class T>
+formattable_ref_impl make_format_value_impl(
+    const T& v,
+    std::false_type,  // writable field
+    std::false_type,  // is formattable range
+    std::false_type   // is formattable ref
+)
+{
+    return {
+        formattable_ref_impl::type_t::fn_and_ptr,
+        formattable_ref_impl::fn_and_ptr{&v, &do_format_custom_formatter<T>}
+    };
+}
+
+// Used for formattable_ref
+// TODO: restructure
+inline formattable_ref_impl make_format_value_impl(
+    formattable_ref v,
+    std::false_type,  // writable field
+    std::false_type,  // is formattable range
+    std::true_type    // is formattable ref
+)
+{
+    return access::get_impl(v);
+}
+
+}  // namespace detail
+}  // namespace mysql
+}  // namespace boost
+
+template <class T>
+boost::mysql::detail::formattable_ref_impl boost::mysql::detail::make_formattable_ref(T&& v)
+{
+    static_assert(
+        is_formattable_type<T>(),
+        "T is not formattable. Please use a formattable type or specialize formatter<T> to make it "
+        "formattable"
+    );
+    return make_format_value_impl(
+        std::forward<T>(v),
+        is_writable_field_ref<T>(),
+        is_formattable_range<T>(),
+        is_formattable_ref<T>()
+    );
+}
+
+#endif

--- a/include/boost/mysql/impl/format_sql.hpp
+++ b/include/boost/mysql/impl/format_sql.hpp
@@ -147,4 +147,32 @@ boost::mysql::detail::formattable_ref_impl boost::mysql::detail::make_formattabl
     );
 }
 
+template <BOOST_MYSQL_FORMATTABLE... Formattable>
+void boost::mysql::format_sql_to(
+    format_context_base& ctx,
+    constant_string_view format_str,
+    Formattable&&... args
+)
+{
+    std::initializer_list<format_arg> args_il{
+        {string_view(), std::forward<Formattable>(args)}
+        ...
+    };
+    format_sql_to(ctx, format_str, args_il);
+}
+
+template <BOOST_MYSQL_FORMATTABLE... Formattable>
+std::string boost::mysql::format_sql(
+    format_options opts,
+    constant_string_view format_str,
+    Formattable&&... args
+)
+{
+    std::initializer_list<format_arg> args_il{
+        {string_view(), std::forward<Formattable>(args)}
+        ...
+    };
+    return format_sql(opts, format_str, args_il);
+}
+
 #endif

--- a/include/boost/mysql/impl/format_sql.ipp
+++ b/include/boost/mysql/impl/format_sql.ipp
@@ -545,23 +545,23 @@ void boost::mysql::format_context_base::format_arg(detail::formattable_ref_impl 
     }
 }
 
-void boost::mysql::detail::vformat_sql_to(
+void boost::mysql::format_sql_to(
     format_context_base& ctx,
-    string_view format_str,
+    constant_string_view format_str,
     std::initializer_list<format_arg> args
 )
 {
-    detail::format_state(ctx, {args.begin(), args.end()}).format(format_str);
+    detail::format_state(ctx, {args.begin(), args.end()}).format(format_str.get());
 }
 
-std::string boost::mysql::detail::vformat_sql(
-    const format_options& opts,
-    string_view format_str,
+std::string boost::mysql::format_sql(
+    format_options opts,
+    constant_string_view format_str,
     std::initializer_list<format_arg> args
 )
 {
     format_context ctx(opts);
-    detail::vformat_sql_to(ctx, format_str, args);
+    format_sql_to(ctx, format_str, args);
     return std::move(ctx).get().value();
 }
 

--- a/include/boost/mysql/impl/format_sql.ipp
+++ b/include/boost/mysql/impl/format_sql.ipp
@@ -525,17 +525,17 @@ public:
 }  // namespace mysql
 }  // namespace boost
 
-void boost::mysql::format_context_base::format_arg(detail::format_arg_value arg, string_view format_spec)
+void boost::mysql::format_context_base::format_arg(detail::formattable_ref_impl arg, string_view format_spec)
 {
     switch (arg.type)
     {
-    case detail::format_arg_value::type_t::field:
+    case detail::formattable_ref_impl::type_t::field:
         detail::append_field_view(arg.data.fv, format_spec, false, *this);
         break;
-    case detail::format_arg_value::type_t::field_with_specs:
+    case detail::formattable_ref_impl::type_t::field_with_specs:
         detail::append_field_view(arg.data.fv, format_spec, true, *this);
         break;
-    case detail::format_arg_value::type_t::custom:
+    case detail::formattable_ref_impl::type_t::fn_and_ptr:
         if (!arg.data.custom.format_fn(arg.data.custom.obj, format_spec.begin(), format_spec.end(), *this))
         {
             add_error(client_errc::format_string_invalid_specifier);

--- a/include/boost/mysql/impl/format_sql.ipp
+++ b/include/boost/mysql/impl/format_sql.ipp
@@ -297,7 +297,7 @@ class format_state
 
     void do_field(format_arg arg, string_view format_spec)
     {
-        ctx_.format_arg(access::get_impl(access::get_impl(arg).value), format_spec);
+        ctx_.format_arg(access::get_impl(arg).value, format_spec);
     }
 
     BOOST_ATTRIBUTE_NODISCARD

--- a/include/boost/mysql/impl/format_sql.ipp
+++ b/include/boost/mysql/impl/format_sql.ipp
@@ -297,7 +297,7 @@ class format_state
 
     void do_field(format_arg arg, string_view format_spec)
     {
-        ctx_.format_arg(access::get_impl(arg).value, format_spec);
+        ctx_.format_arg(access::get_impl(access::get_impl(arg).value), format_spec);
     }
 
     BOOST_ATTRIBUTE_NODISCARD

--- a/test/integration/test/snippets/sql_formatting.cpp
+++ b/test/integration/test/snippets/sql_formatting.cpp
@@ -604,6 +604,21 @@ BOOST_AUTO_TEST_CASE(section_sql_formatting)
         );
         //->
         //]
+
+        //[sql_formatting_reference_formattable_ref
+        //<-
+        BOOST_TEST(
+            //->
+            format_sql(opts, "SELECT {}", formattable_ref(42)) == "SELECT 42"
+            //<-
+        );
+        BOOST_TEST(
+            //->
+            format_sql(opts, "SELECT {:i} FROM t", formattable_ref("salary")) == "SELECT `salary` FROM t"
+            //<-
+        );
+        //->
+        //]
     }
 
     // Advanced section

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -83,6 +83,7 @@ add_executable(
     test/format_sql/formattable.cpp
     test/format_sql/basic_format_context.cpp
     test/format_sql/individual_value.cpp
+    test/format_sql/formattable_ref.cpp
     test/format_sql/ranges.cpp
     test/format_sql/sequence.cpp
     test/format_sql/custom_formatter.cpp

--- a/test/unit/Jamfile
+++ b/test/unit/Jamfile
@@ -92,6 +92,7 @@ run
         test/format_sql/formattable.cpp
         test/format_sql/basic_format_context.cpp
         test/format_sql/individual_value.cpp
+        test/format_sql/formattable_ref.cpp
         test/format_sql/ranges.cpp
         test/format_sql/sequence.cpp
         test/format_sql/custom_formatter.cpp

--- a/test/unit/test/format_sql/formattable_ref.cpp
+++ b/test/unit/test/format_sql/formattable_ref.cpp
@@ -1,0 +1,91 @@
+//
+// Copyright (c) 2019-2024 Ruben Perez Hidalgo (rubenperez038 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/format_sql.hpp>
+
+#include <boost/optional/optional.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <type_traits>
+#include <vector>
+
+#include "format_common.hpp"
+
+using namespace boost::mysql;
+
+BOOST_AUTO_TEST_SUITE(test_formattable_ref)
+
+constexpr format_options opts{utf8mb4_charset, true};
+constexpr const char* single_fmt = "SELECT {};";
+
+//
+// Basic operations on formattable_ref work
+//
+BOOST_AUTO_TEST_CASE(copy_ctor)
+{
+    // Regression check: the universal reference ctor. is suitably constrained
+    static_assert(std::is_trivially_copy_constructible<formattable_ref>::value, "");
+
+    formattable_ref ref1{42};
+    formattable_ref ref2{ref1};
+    BOOST_TEST(format_sql(opts, single_fmt, ref2) == "SELECT 42;");
+}
+
+BOOST_AUTO_TEST_CASE(move_ctor)
+{
+    // Regression check: the universal reference ctor. is suitably constrained
+    static_assert(std::is_trivially_move_constructible<formattable_ref>::value, "");
+
+    formattable_ref ref1{42};
+    formattable_ref ref2{std::move(ref1)};
+    BOOST_TEST(format_sql(opts, single_fmt, ref2) == "SELECT 42;");
+}
+
+// The universal reference ctor. is SFINAE friendly
+struct unrelated
+{
+};
+
+std::true_type f(unrelated) { return {}; }
+std::false_type f(formattable_ref) { return {}; }
+
+static_assert(decltype(f(unrelated{}))::value, "SFINAE check failed");
+
+//
+// Formatting a formattable_ref works
+//
+BOOST_AUTO_TEST_CASE(formatting)
+{
+    // Scalar values
+    BOOST_TEST(format_sql(opts, single_fmt, formattable_ref{"abc"}) == "SELECT 'abc';");
+
+    // Optionals
+    BOOST_TEST(format_sql(opts, single_fmt, formattable_ref{boost::optional<int>{}}) == "SELECT NULL;");
+
+    // Fields
+    BOOST_TEST(format_sql(opts, single_fmt, formattable_ref{field_view(42)}) == "SELECT 42;");
+
+    // Ranges
+    std::vector<int> vals{4, 10, 1};
+    BOOST_TEST(format_sql(opts, single_fmt, formattable_ref{vals}) == "SELECT 4, 10, 1;");
+
+    // Types with custom formatter
+    custom::condition cond{"key", 10};
+    BOOST_TEST(format_sql(opts, single_fmt, formattable_ref{cond}) == "SELECT `key`=10;");
+    BOOST_TEST(format_sql(opts, single_fmt, formattable_ref{custom::condition(cond)}) == "SELECT `key`=10;");
+
+    // Specifiers
+    BOOST_TEST(format_sql(opts, "{:s}", formattable_ref{cond}) == "`key` = 10");
+}
+
+BOOST_AUTO_TEST_CASE(range_of_refs)
+{
+    std::vector<formattable_ref> args{42, "abc", nullptr};
+    BOOST_TEST(format_sql(opts, single_fmt, args) == "SELECT 42, 'abc', NULL;");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
format_context_base::append_value now uses formattable_ref instead of being a template

close #284 