### PR TITLE
Character set clean-up

### DIFF
--- a/include/boost/mysql/character_set.hpp
+++ b/include/boost/mysql/character_set.hpp
@@ -8,11 +8,8 @@
 #ifndef BOOST_MYSQL_CHARACTER_SET_HPP
 #define BOOST_MYSQL_CHARACTER_SET_HPP
 
-#include <boost/mysql/string_view.hpp>
-
 #include <boost/mysql/detail/character_set.hpp>
 #include <boost/mysql/detail/config.hpp>
-#include <boost/mysql/detail/make_string_view.hpp>
 
 #include <boost/core/span.hpp>
 
@@ -31,13 +28,13 @@ namespace mysql {
 struct character_set
 {
     /**
-     * \brief The character set name.
+     * \brief The character set name, as a NULL-terminated string.
      * \details
      * This should match the character set name in MySQL. This is the string
      * you specify when issuing `SET NAMES` statements. You can find available
      * character sets using the `SHOW CHARACTER SET` statement.
      */
-    string_view name;
+    const char* name;
 
     /**
      * \brief Obtains the size of the first character of a string.
@@ -55,22 +52,22 @@ struct character_set
      * \n
      * \par Function signature
      * The function signature should be:
-     * `std::size_t (*next_char)(boost::span<const unsigned char> r) noexcept`.
+     * `std::size_t (*next_char)(boost::span<const unsigned char> r)`.
      */
-    std::size_t (*next_char)(span<const unsigned char>) noexcept;
+    std::size_t (*next_char)(span<const unsigned char>);
 };
 
 /// (EXPERIMENTAL) The utf8mb4 character set (the one you should use by default).
 BOOST_INLINE_CONSTEXPR character_set utf8mb4_charset
 #ifndef BOOST_MYSQL_DOXYGEN
-    {detail::make_string_view("utf8mb4"), detail::next_char_utf8mb4}
+    {"utf8mb4", detail::next_char_utf8mb4}
 #endif
 ;
 
 /// (EXPERIMENTAL) The ascii character set.
 BOOST_INLINE_CONSTEXPR character_set ascii_charset
 #ifndef BOOST_MYSQL_DOXYGEN
-    {detail::make_string_view("ascii"), detail::next_char_ascii};
+    {"ascii", detail::next_char_ascii};
 #endif
 ;
 

--- a/include/boost/mysql/detail/character_set.hpp
+++ b/include/boost/mysql/detail/character_set.hpp
@@ -8,8 +8,6 @@
 #ifndef BOOST_MYSQL_DETAIL_CHARACTER_SET_HPP
 #define BOOST_MYSQL_DETAIL_CHARACTER_SET_HPP
 
-#include <boost/mysql/string_view.hpp>
-
 #include <boost/mysql/detail/config.hpp>
 
 #include <boost/core/span.hpp>
@@ -20,11 +18,8 @@ namespace boost {
 namespace mysql {
 namespace detail {
 
-inline std::size_t next_char_ascii(span<const unsigned char> input) noexcept
-{
-    return input[0] <= 0x7f ? 1 : 0;
-}
-BOOST_MYSQL_DECL std::size_t next_char_utf8mb4(span<const unsigned char> input) noexcept;
+inline std::size_t next_char_ascii(span<const unsigned char> input) { return input[0] <= 0x7f ? 1 : 0; }
+BOOST_MYSQL_DECL std::size_t next_char_utf8mb4(span<const unsigned char> input);
 
 }  // namespace detail
 }  // namespace mysql

--- a/include/boost/mysql/impl/character_set.ipp
+++ b/include/boost/mysql/impl/character_set.ipp
@@ -16,7 +16,7 @@ namespace boost {
 namespace mysql {
 namespace detail {
 
-inline bool in_range(unsigned char byte, unsigned char lower, unsigned char upper) noexcept
+inline bool in_range(unsigned char byte, unsigned char lower, unsigned char upper)
 {
     return byte >= lower && byte <= upper;
 }
@@ -25,7 +25,7 @@ inline bool in_range(unsigned char byte, unsigned char lower, unsigned char uppe
 }  // namespace mysql
 }  // namespace boost
 
-std::size_t boost::mysql::detail::next_char_utf8mb4(span<const unsigned char> input) noexcept
+std::size_t boost::mysql::detail::next_char_utf8mb4(span<const unsigned char> input)
 {
     // s[0]    s[1]    s[2]    s[3]    comment
     // 00-7F                           ascii

--- a/include/boost/mysql/impl/character_set.ipp
+++ b/include/boost/mysql/impl/character_set.ipp
@@ -12,6 +12,8 @@
 
 #include <boost/mysql/character_set.hpp>
 
+#include <boost/assert.hpp>
+
 namespace boost {
 namespace mysql {
 namespace detail {

--- a/include/boost/mysql/impl/connection_impl.ipp
+++ b/include/boost/mysql/impl/connection_impl.ipp
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <boost/mysql/character_set.hpp>
+
 #include <boost/mysql/detail/connection_impl.hpp>
 
 #include <boost/mysql/impl/internal/sansio/connection_state.hpp>
@@ -51,10 +53,10 @@ boost::mysql::diagnostics& boost::mysql::detail::connection_impl::shared_diag()
 boost::system::result<boost::mysql::character_set> boost::mysql::detail::connection_impl::
     current_character_set() const
 {
-    const auto* res = st_->data().charset_ptr();
-    if (res == nullptr)
+    character_set charset = st_->data().current_charset;
+    if (charset.name == nullptr)
         return client_errc::unknown_character_set;
-    return *res;
+    return charset;
 }
 
 template <class AlgoParams>

--- a/include/boost/mysql/impl/internal/sansio/connection_state_data.hpp
+++ b/include/boost/mysql/impl/internal/sansio/connection_state_data.hpp
@@ -80,11 +80,6 @@ struct connection_state_data
     bool ssl_active() const { return ssl == ssl_state::active; }
     bool supports_ssl() const { return ssl != ssl_state::unsupported; }
 
-    const character_set* charset_ptr() const
-    {
-        return current_charset.name.empty() ? nullptr : &current_charset;
-    }
-
     connection_state_data(std::size_t read_buffer_size, bool transport_supports_ssl = false)
         : ssl(transport_supports_ssl ? ssl_state::inactive : ssl_state::unsupported), reader(read_buffer_size)
     {

--- a/include/boost/mysql/impl/internal/sansio/set_character_set.hpp
+++ b/include/boost/mysql/impl/internal/sansio/set_character_set.hpp
@@ -32,12 +32,8 @@ namespace detail {
 // Securely compose a SET NAMES statement
 inline system::result<std::string> compose_set_names(character_set charset)
 {
-    // The character set should have a non-empty name (should not be default-constructed)
-    BOOST_ASSERT(!charset.name.empty());
-
-    // NULL characters cause MySQL to truncate the character set name string
-    if (charset.name.contains('\0'))
-        return client_errc::invalid_encoding;
+    // The character set should not be default-constructed
+    BOOST_ASSERT(charset.name != nullptr);
 
     // For security, if the character set has non-ascii characters in it name, reject it.
     format_context ctx(format_options{ascii_charset, true});

--- a/test/common/src/printing.cpp
+++ b/test/common/src/printing.cpp
@@ -81,12 +81,16 @@ std::ostream& boost::mysql::operator<<(std::ostream& os, ssl_mode v) { return os
 // character set
 bool boost::mysql::operator==(const character_set& lhs, const character_set& rhs)
 {
-    return lhs.name == rhs.name;
+    return lhs.name == rhs.name && lhs.next_char == rhs.next_char;
 }
 
 std::ostream& boost::mysql::operator<<(std::ostream& os, const character_set& v)
 {
-    return os << "character_set(\"" << v.name << "\")";
+    if (v.name == nullptr)
+        return os << "character_set()";
+    else
+        return os << "character_set(\"" << v.name << "\", .next_char? = " << static_cast<bool>(v.next_char)
+                  << ")";
 }
 
 // errcode_with_diagnostics

--- a/test/common/src/printing.cpp
+++ b/test/common/src/printing.cpp
@@ -81,7 +81,8 @@ std::ostream& boost::mysql::operator<<(std::ostream& os, ssl_mode v) { return os
 // character set
 bool boost::mysql::operator==(const character_set& lhs, const character_set& rhs)
 {
-    return lhs.name == rhs.name && lhs.next_char == rhs.next_char;
+    // Note: comparing function pointers can be unreliable
+    return lhs.name == rhs.name;
 }
 
 std::ostream& boost::mysql::operator<<(std::ostream& os, const character_set& v)
@@ -89,8 +90,7 @@ std::ostream& boost::mysql::operator<<(std::ostream& os, const character_set& v)
     if (v.name == nullptr)
         return os << "character_set()";
     else
-        return os << "character_set(\"" << v.name << "\", .next_char? = " << static_cast<bool>(v.next_char)
-                  << ")";
+        return os << "character_set(\"" << v.name << "\")";
 }
 
 // errcode_with_diagnostics

--- a/test/common/src/printing.cpp
+++ b/test/common/src/printing.cpp
@@ -20,6 +20,7 @@
 
 #include <boost/mysql/detail/access.hpp>
 
+#include <cstring>
 #include <ostream>
 
 #include "test_common/printing.hpp"
@@ -81,8 +82,7 @@ std::ostream& boost::mysql::operator<<(std::ostream& os, ssl_mode v) { return os
 // character set
 bool boost::mysql::operator==(const character_set& lhs, const character_set& rhs)
 {
-    // Note: comparing function pointers can be unreliable
-    return lhs.name == rhs.name;
+    return std::strcmp(lhs.name, rhs.name) == 0 && lhs.next_char == rhs.next_char;
 }
 
 std::ostream& boost::mysql::operator<<(std::ostream& os, const character_set& v)
@@ -90,7 +90,8 @@ std::ostream& boost::mysql::operator<<(std::ostream& os, const character_set& v)
     if (v.name == nullptr)
         return os << "character_set()";
     else
-        return os << "character_set(\"" << v.name << "\")";
+        return os << "character_set(\"" << v.name << "\", .next_char? = " << static_cast<bool>(v.next_char)
+                  << ")";
 }
 
 // errcode_with_diagnostics

--- a/test/common/src/printing.cpp
+++ b/test/common/src/printing.cpp
@@ -82,6 +82,8 @@ std::ostream& boost::mysql::operator<<(std::ostream& os, ssl_mode v) { return os
 // character set
 bool boost::mysql::operator==(const character_set& lhs, const character_set& rhs)
 {
+    if (lhs.name == nullptr || rhs.name == nullptr)
+        return lhs.name == rhs.name;
     return std::strcmp(lhs.name, rhs.name) == 0 && lhs.next_char == rhs.next_char;
 }
 

--- a/test/fuzzing/fuzz_utf8mb4.cpp
+++ b/test/fuzzing/fuzz_utf8mb4.cpp
@@ -10,6 +10,7 @@
 #include <boost/mysql/impl/internal/call_next_char.hpp>
 
 #include <cstddef>
+#include <stdint.h>
 
 using namespace boost::mysql;
 

--- a/test/integration/test/snippets/charsets.cpp
+++ b/test/integration/test/snippets/charsets.cpp
@@ -23,7 +23,7 @@ namespace {
 // utf8mb4 character set and return the size of the first character,
 // or 0 if the byte sequence does not represent a valid character.
 // It must not throw exceptions.
-std::size_t utf8mb4_next_char(boost::span<const unsigned char> input) noexcept
+std::size_t utf8mb4_next_char(boost::span<const unsigned char> input)
 {
     // Input strings are never empty - they always have 1 byte, at least.
     assert(!input.empty());

--- a/test/unit/include/test_unit/ff_charset.hpp
+++ b/test/unit/include/test_unit/ff_charset.hpp
@@ -10,21 +10,19 @@
 
 #include <boost/mysql/character_set.hpp>
 
-#include <boost/mysql/detail/make_string_view.hpp>
-
 namespace boost {
 namespace mysql {
 namespace test {
 
 // A hypothetical character set with rules that may confuse formatting algorithms.
 // Some MySQL charsets (e.g. gbk) contain ASCII-compatible continuation characters, like this one.
-inline std::size_t ff_charset_next_char(boost::span<const unsigned char> r) noexcept
+inline std::size_t ff_charset_next_char(boost::span<const unsigned char> r)
 {
     if (r[0] == 0xff)  // 0xff marks a two-byte character
         return r.size() > 1u ? 2u : 0u;
     return 1u;
 };
-constexpr character_set ff_charset{detail::make_string_view("ff_charset"), ff_charset_next_char};
+constexpr character_set ff_charset{"ff_charset", ff_charset_next_char};
 
 }  // namespace test
 }  // namespace mysql

--- a/test/unit/test/sansio/reset_connection.cpp
+++ b/test/unit/test/sansio/reset_connection.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(read_response_success)
 
     // The OK packet was processed correctly. The charset was reset
     BOOST_TEST(fix.st.backslash_escapes);
-    BOOST_TEST(fix.st.charset_ptr() == nullptr);
+    BOOST_TEST(fix.st.current_charset == character_set());
 }
 
 BOOST_AUTO_TEST_CASE(read_response_success_no_backslash_escapes)
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(read_response_success_no_backslash_escapes)
     // The OK packet was processed correctly.
     // It's OK to run this algo without a known charset
     BOOST_TEST(!fix.st.backslash_escapes);
-    BOOST_TEST(fix.st.charset_ptr() == nullptr);
+    BOOST_TEST(fix.st.current_charset == character_set());
 }
 
 BOOST_AUTO_TEST_CASE(read_response_error_network)
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(read_response_error_packet)
         .check(fix, common_server_errc::er_bad_db_error, create_server_diag("my_message"));
 
     // The charset was not updated
-    BOOST_TEST(fix.st.charset_ptr()->name == "utf8mb4");
+    BOOST_TEST(fix.st.current_charset == utf8mb4_charset);
 }
 
 //
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(success)
 
     // The OK packet was processed correctly. The charset was reset
     BOOST_TEST(fix.st.backslash_escapes);
-    BOOST_TEST(fix.st.charset_ptr() == nullptr);
+    BOOST_TEST(fix.st.current_charset == character_set());
 }
 
 BOOST_AUTO_TEST_CASE(reset_conn_error_network)
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(reset_conn_error_response)
         .check(fix, common_server_errc::er_bad_db_error, create_server_diag("my_message"));
 
     // The charset was not updated
-    BOOST_TEST(fix.st.charset_ptr()->name == "utf8mb4");
+    BOOST_TEST(fix.st.current_charset == utf8mb4_charset);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/test/sansio/run_pipeline.cpp
+++ b/test/unit/test/sansio/run_pipeline.cpp
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(reset_connection)
     fix.check_all_stages_succeeded();
 
     // The current character set was reset
-    BOOST_TEST(fix.st.charset_ptr() == nullptr);
+    BOOST_TEST(fix.st.current_charset == character_set());
 }
 
 BOOST_AUTO_TEST_CASE(set_character_set)
@@ -291,7 +291,7 @@ BOOST_AUTO_TEST_CASE(set_character_set)
     fix.check_all_stages_succeeded();
 
     // The current character set was set
-    BOOST_TEST(fix.st.charset_ptr()->name == "utf8mb4");
+    BOOST_TEST(fix.st.current_charset == utf8mb4_charset);
 }
 
 BOOST_AUTO_TEST_CASE(ping)
@@ -352,7 +352,7 @@ BOOST_AUTO_TEST_CASE(combination)
 
     // The pipeline had its intended effect
     BOOST_TEST(fix.st.backslash_escapes == true);
-    BOOST_TEST(fix.st.charset_ptr()->name == "utf8mb4");
+    BOOST_TEST(fix.st.current_charset == utf8mb4_charset);
     BOOST_TEST(fix.resp.items.at(3).stmt.id() == 3u);
     BOOST_TEST(fix.resp.items.at(4).stmt.id() == 1u);
 }


### PR DESCRIPTION
character_set::name is now a const char*, since NULL characters are not allowed by MySQL
character_set::next_char doesn't need to be noexcept
Removed noexcepts from next_char functions
Internal refactor