### PR TITLE
Improved tracker_executor

### DIFF
--- a/test/common/include/test_common/netfun_maker.hpp
+++ b/test/common/include/test_common/netfun_maker.hpp
@@ -168,14 +168,8 @@ public:
         return impl::sync_errc_noerrinfo(pfn);
     }
     static signature sync_exc(sig_sync_exc pfn) { return impl::sync_exc(pfn); }
-    static signature async_errinfo(sig_async_errinfo pfn, bool validate_exec_info = true)
-    {
-        return impl::async_errinfo(pfn, validate_exec_info);
-    }
-    static signature async_noerrinfo(sig_async_noerrinfo pfn, bool validate_exec_info = true)
-    {
-        return impl::async_noerrinfo(pfn, validate_exec_info);
-    }
+    static signature async_errinfo(sig_async_errinfo pfn) { return impl::async_errinfo(pfn); }
+    static signature async_noerrinfo(sig_async_noerrinfo pfn) { return impl::async_noerrinfo(pfn); }
 };
 
 }  // namespace test

--- a/test/common/include/test_common/netfun_maker.hpp
+++ b/test/common/include/test_common/netfun_maker.hpp
@@ -68,48 +68,59 @@ struct netfun_maker_impl
     }
 
     template <class Pfn>
-    static signature async_errinfo(Pfn fn, bool validate_exec_info = true)
+    static signature async_errinfo(Pfn fn)
     {
-        return [fn, validate_exec_info](IOObject& obj, Args... args) {
-            auto io_obj_executor = obj.get_executor();
-            executor_info exec_info{};
+        return [fn](IOObject& obj, Args... args) {
+            // Get the object's I/O executor
+            auto ex = obj.get_executor();
+
+            // Create the initial result
             auto res = create_initial_netresult<R>();
-            invoke_polyfill(
-                fn,
-                obj,
-                std::forward<Args>(args)...,
-                *res.diag,
-                as_network_result<R>(res, create_tracker_executor(obj.get_executor(), &exec_info))
-            );
-            run_until_completion(io_obj_executor);
-            if (validate_exec_info)
+
             {
-                BOOST_TEST(get_executor_info(io_obj_executor).num_posts > 0u);
-                BOOST_TEST(exec_info.num_dispatches > 0u);
+                // Mark ourselves as initiating
+                initiation_guard guard;
+
+                // Invoke the initiation function
+                invoke_polyfill(
+                    fn,
+                    obj,
+                    std::forward<Args>(args)...,
+                    *res.diag,
+                    as_network_result<R>(res, ex)
+                );
             }
+
+            // Run
+            run_until_completion(ex);
+
+            // Done
             return res;
         };
     }
 
     template <class Pfn>
-    static signature async_noerrinfo(Pfn fn, bool validate_exec_info = true)
+    static signature async_noerrinfo(Pfn fn)
     {
-        return [fn, validate_exec_info](IOObject& obj, Args... args) {
-            auto io_obj_executor = obj.get_executor();
-            executor_info exec_info{};
+        return [fn](IOObject& obj, Args... args) {
+            // Get the object's I/O executor
+            auto ex = obj.get_executor();
+
+            // Create the initial result
             auto res = create_initial_netresult<R>(false);
-            invoke_polyfill(
-                fn,
-                obj,
-                std::forward<Args>(args)...,
-                as_network_result<R>(res, create_tracker_executor(obj.get_executor(), &exec_info))
-            );
-            run_until_completion(io_obj_executor);
-            if (validate_exec_info)
+
             {
-                BOOST_TEST(get_executor_info(io_obj_executor).num_posts > 0u);
-                BOOST_TEST(exec_info.num_dispatches > 0u);
+                // Mark ourselves as initiating
+                initiation_guard guard;
+
+                // Invoke the initiation function
+                invoke_polyfill(fn, obj, std::forward<Args>(args)..., as_network_result<R>(res, ex));
             }
+
+            // Run until completion
+            run_until_completion(ex);
+
+            // Done
             return res;
         };
     }
@@ -134,14 +145,8 @@ public:
         return impl::sync_errc_noerrinfo(pfn);
     }
     static signature sync_exc(sig_sync_exc pfn) { return impl::sync_exc(pfn); }
-    static signature async_errinfo(sig_async_errinfo pfn, bool validate_exec_info = true)
-    {
-        return impl::async_errinfo(pfn, validate_exec_info);
-    }
-    static signature async_noerrinfo(sig_async_noerrinfo pfn, bool validate_exec_info = true)
-    {
-        return impl::async_noerrinfo(pfn, validate_exec_info);
-    }
+    static signature async_errinfo(sig_async_errinfo pfn) { return impl::async_errinfo(pfn); }
+    static signature async_noerrinfo(sig_async_noerrinfo pfn) { return impl::async_noerrinfo(pfn); }
 };
 
 template <class R, class... Args>

--- a/test/common/src/tracker_executor.cpp
+++ b/test/common/src/tracker_executor.cpp
@@ -5,16 +5,68 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#include "test_common/tracker_executor.hpp"
-
 #include <boost/asio/execution/blocking.hpp>
 #include <boost/asio/execution/relationship.hpp>
 #include <boost/asio/execution_context.hpp>
 #include <boost/asio/require.hpp>
+#include <boost/function/function_base.hpp>
+#include <boost/test/tools/interface.hpp>
 
+#include <atomic>
+#include <type_traits>
 #include <utility>
+#include <vector>
+
+#include "test_common/tracker_executor.hpp"
 
 using namespace boost::mysql::test;
+
+namespace {
+
+// Are we in the call stack of an initiating function?
+thread_local bool g_is_running_initiation = false;
+
+// Produce unique executor IDs (start in 1)
+std::atomic_int next_executor_id{1};
+
+// The executor call stack
+thread_local std::vector<int> g_executor_call_stack;
+
+// Guard to remove an entry from the stack
+struct executor_call_stack_guard
+{
+    executor_call_stack_guard(int executor_id) { g_executor_call_stack.push_back(executor_id); }
+    executor_call_stack_guard(const executor_call_stack_guard&) = delete;
+    executor_call_stack_guard(executor_call_stack_guard&&) = delete;
+    executor_call_stack_guard& operator=(const executor_call_stack_guard&) = delete;
+    executor_call_stack_guard& operator=(executor_call_stack_guard&&) = delete;
+    ~executor_call_stack_guard() { g_executor_call_stack.pop_back(); }
+};
+
+// Wraps a function object to insert tracking of the caller executor
+template <class Function>
+struct tracker_executor_function
+{
+    int executor_id;
+    Function fn;
+
+    void operator()()
+    {
+        executor_call_stack_guard guard(executor_id);
+        std::move(fn)();
+    }
+};
+
+template <class Function>
+tracker_executor_function<typename std::decay<Function>::type> create_tracker_executor_function(
+    int executor_id,
+    Function&& fn
+)
+{
+    return {executor_id, std::forward<Function>(fn)};
+}
+
+}  // namespace
 
 namespace boost {
 namespace mysql {
@@ -23,34 +75,11 @@ namespace test {
 class tracker_executor
 {
 public:
-    tracker_executor(boost::asio::any_io_executor ex, executor_info* tracked) noexcept
-        : ex_(ex), tracked_(tracked)
-    {
-    }
+    tracker_executor(int id, boost::asio::any_io_executor ex) noexcept : id_(id), ex_(std::move(ex)) {}
 
-    tracker_executor(const tracker_executor& rhs) noexcept : ex_(rhs.ex_), tracked_(rhs.tracked_) {}
-    tracker_executor(tracker_executor&& rhs) noexcept : ex_(std::move(rhs.ex_)), tracked_(rhs.tracked_) {}
-    tracker_executor& operator=(const tracker_executor& rhs) noexcept
-    {
-        ex_ = rhs.ex_;
-        tracked_ = rhs.tracked_;
-        return *this;
-    }
-    tracker_executor& operator=(tracker_executor&& rhs) noexcept
-    {
-        ex_ = std::move(rhs.ex_);
-        tracked_ = std::move(rhs.tracked_);
-        return *this;
-    }
-    ~tracker_executor() = default;
-
-    bool operator==(const tracker_executor& rhs) const noexcept
-    {
-        return ex_ == rhs.ex_ && tracked_ == rhs.tracked_;
-    }
+    bool operator==(const tracker_executor& rhs) const noexcept { return id_ == rhs.id_ && ex_ == rhs.ex_; }
     bool operator!=(const tracker_executor& rhs) const noexcept { return !(*this == rhs); }
-
-    executor_info* get_tracked() const noexcept { return tracked_; }
+    int id() const { return id_; }
 
 #ifdef BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT
 
@@ -62,21 +91,19 @@ public:
     template <typename Function, typename Allocator>
     void dispatch(Function&& f, const Allocator& a) const
     {
-        ++tracked_->num_dispatches;
-        ex_.dispatch(std::forward<Function>(f), a);
+        ex_.dispatch(create_tracker_executor_function(id_, std::forward<Function>(f)), a);
     }
 
     template <typename Function, typename Allocator>
     void post(Function&& f, const Allocator& a) const
     {
-        ++tracked_->num_posts;
-        ex_.post(std::forward<Function>(f), a);
+        ex_.post(create_tracker_executor_function(id_, std::forward<Function>(f)), a);
     }
 
     template <typename Function, typename Allocator>
     void defer(Function&& f, const Allocator& a) const
     {
-        ex_.defer(std::forward<Function>(f), a);
+        ex_.defer(create_tracker_executor_function(id_, std::forward<Function>(f)), a);
     }
 
 #else
@@ -88,7 +115,7 @@ public:
         typename std::enable_if<asio::can_require<asio::any_io_executor, Property>::value>::type* = nullptr
     ) const
     {
-        return tracker_executor(asio::require(ex_, p), tracked_);
+        return tracker_executor(id_, asio::require(ex_, p));
     }
 
     template <class Property>
@@ -97,7 +124,7 @@ public:
         typename std::enable_if<asio::can_prefer<asio::any_io_executor, Property>::value>::type* = nullptr
     ) const
     {
-        return tracker_executor(asio::prefer(ex_, p), tracked_);
+        return tracker_executor(id_, asio::prefer(ex_, p));
     }
 
     template <class Property>
@@ -112,24 +139,13 @@ public:
     template <typename Function>
     void execute(Function&& f) const
     {
-        if (asio::query(ex_, asio::execution::relationship) == asio::execution::relationship.fork &&
-            asio::query(ex_, asio::execution::blocking) == asio::execution::blocking.never)
-        {
-            // This is a post
-            ++tracked_->num_posts;
-        }
-        else
-        {
-            ++tracked_->num_dispatches;
-        }
-        ex_.execute(std::forward<Function>(f));
+        ex_.execute(create_tracker_executor_function(id_, std::forward<Function>(f)));
     }
-
 #endif
 
 private:
+    int id_;
     boost::asio::any_io_executor ex_;
-    executor_info* tracked_;
 };
 
 }  // namespace test
@@ -196,15 +212,29 @@ struct query_member<
 }  // namespace asio
 }  // namespace boost
 
-boost::asio::any_io_executor boost::mysql::test::create_tracker_executor(
-    asio::any_io_executor inner,
-    executor_info* tracked_values
+boost::mysql::test::tracker_executor_result boost::mysql::test::create_tracker_executor(
+    asio::any_io_executor inner
 )
 {
-    return tracker_executor(std::move(inner), tracked_values);
+    int id = ++next_executor_id;
+    return {id, tracker_executor(id, std::move(inner))};
 }
 
-executor_info boost::mysql::test::get_executor_info(const asio::any_io_executor& exec)
+int boost::mysql::test::current_executor_id()
 {
-    return *exec.target<tracker_executor>()->get_tracked();
+    return g_executor_call_stack.empty() ? -1 : g_executor_call_stack.back();
 }
+
+boost::mysql::test::initiation_guard::initiation_guard()
+{
+    BOOST_TEST_REQUIRE(!g_is_running_initiation);
+    g_is_running_initiation = true;
+}
+
+boost::mysql::test::initiation_guard::~initiation_guard()
+{
+    BOOST_ASSERT(g_is_running_initiation);
+    g_is_running_initiation = false;
+}
+
+bool boost::mysql::test::is_initiation_function() { return g_is_running_initiation; }

--- a/test/common/src/tracker_executor.cpp
+++ b/test/common/src/tracker_executor.cpp
@@ -9,8 +9,7 @@
 #include <boost/asio/execution/relationship.hpp>
 #include <boost/asio/execution_context.hpp>
 #include <boost/asio/require.hpp>
-#include <boost/function/function_base.hpp>
-#include <boost/test/tools/interface.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <atomic>
 #include <type_traits>

--- a/test/integration/test/any_connection.cpp
+++ b/test/integration/test/any_connection.cpp
@@ -52,8 +52,8 @@ using netmaker_connect = netfun_maker_mem<void, any_connection, const connect_pa
 using netmaker_execute = netfun_maker_mem<void, any_connection, const string_view&, results&>;
 
 // Don't validate executor info, since our I/O objects don't use tracker executors
-const auto connect_fn = netmaker_connect::async_errinfo(&any_connection::async_connect, false);
-const auto execute_fn = netmaker_execute::async_errinfo(&any_connection::async_execute, false);
+const auto connect_fn = netmaker_connect::async_errinfo(&any_connection::async_connect);
+const auto execute_fn = netmaker_execute::async_errinfo(&any_connection::async_execute);
 
 // Passing no SSL context to the constructor and using SSL works.
 // ssl_mode::require works

--- a/test/integration/test/reconnect.cpp
+++ b/test/integration/test/reconnect.cpp
@@ -30,12 +30,9 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/unit_test_suite.hpp>
 
-#include <exception>
-
 #include "test_common/netfun_maker.hpp"
 #include "test_integration/common.hpp"
 #include "test_integration/er_network_variant.hpp"
-#include "test_integration/get_endpoint.hpp"
 #include "test_integration/network_samples.hpp"
 #include "test_integration/run_stackful_coro.hpp"
 #include "test_integration/server_features.hpp"
@@ -229,8 +226,8 @@ struct change_stream_type_fixture : network_fixture_base
     };
 
     functions_t async_fns{
-        netmaker_connect::async_errinfo(&any_connection::async_connect, false),
-        netmaker_ping::async_errinfo(&any_connection::async_ping, false),
+        netmaker_connect::async_errinfo(&any_connection::async_connect),
+        netmaker_ping::async_errinfo(&any_connection::async_ping),
     };
 
     connect_params tcp_params;

--- a/test/integration/test/spotchecks.cpp
+++ b/test/integration/test/spotchecks.cpp
@@ -505,11 +505,10 @@ struct
     string_view name;
     set_charset_netmaker::signature set_character_set;
 } set_charset_all_fns[] = {
-    {"sync_errc", set_charset_netmaker::sync_errc(&any_connection::set_character_set)},
-    {"sync_exc", set_charset_netmaker::sync_exc(&any_connection::set_character_set)},
-    {"async_errinfo", set_charset_netmaker::async_errinfo(&any_connection::async_set_character_set, false)},
-    {"async_noerrinfo", set_charset_netmaker::async_noerrinfo(&any_connection::async_set_character_set, false)
-    },
+    {"sync_errc",       set_charset_netmaker::sync_errc(&any_connection::set_character_set)            },
+    {"sync_exc",        set_charset_netmaker::sync_exc(&any_connection::set_character_set)             },
+    {"async_errinfo",   set_charset_netmaker::async_errinfo(&any_connection::async_set_character_set)  },
+    {"async_noerrinfo", set_charset_netmaker::async_noerrinfo(&any_connection::async_set_character_set)},
 };
 
 BOOST_AUTO_TEST_CASE(set_character_set_success)
@@ -568,10 +567,10 @@ struct
     string_view name;
     run_pipeline_netmaker::signature run_pipeline;
 } run_pipeline_all_fns[] = {
-    {"sync_errc", run_pipeline_netmaker::sync_errc(&any_connection::run_pipeline)},
-    {"sync_exc", run_pipeline_netmaker::sync_exc(&any_connection::run_pipeline)},
-    {"async_errinfo", run_pipeline_netmaker::async_errinfo(&any_connection::async_run_pipeline, false)},
-    {"async_noerrinfo", run_pipeline_netmaker::async_noerrinfo(&any_connection::async_run_pipeline, false)},
+    {"sync_errc",       run_pipeline_netmaker::sync_errc(&any_connection::run_pipeline)            },
+    {"sync_exc",        run_pipeline_netmaker::sync_exc(&any_connection::run_pipeline)             },
+    {"async_errinfo",   run_pipeline_netmaker::async_errinfo(&any_connection::async_run_pipeline)  },
+    {"async_noerrinfo", run_pipeline_netmaker::async_noerrinfo(&any_connection::async_run_pipeline)},
 };
 
 BOOST_AUTO_TEST_CASE(run_pipeline_success)

--- a/test/unit/include/test_unit/test_stream.hpp
+++ b/test/unit/include/test_unit/test_stream.hpp
@@ -20,7 +20,6 @@
 #include <set>
 #include <vector>
 
-#include "test_common/tracker_executor.hpp"
 #include "test_unit/fail_count.hpp"
 
 namespace boost {
@@ -80,7 +79,6 @@ private:
     std::vector<std::uint8_t> bytes_written_;
     fail_count fail_count_;
     std::size_t write_break_size_{1024};  // max number of bytes to be written in each write_some
-    executor_info executor_info_{};
 
     std::size_t get_size_to_read(std::size_t buffer_size) const;
     std::size_t do_read(asio::mutable_buffer buff, error_code& ec);

--- a/test/unit/src/test_stream.cpp
+++ b/test/unit/src/test_stream.cpp
@@ -5,8 +5,6 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#include "test_unit/test_stream.hpp"
-
 #include <boost/mysql/error_code.hpp>
 
 #include <boost/asio/buffer.hpp>
@@ -25,7 +23,7 @@
 #include <vector>
 
 #include "test_common/buffer_concat.hpp"
-#include "test_common/tracker_executor.hpp"
+#include "test_unit/test_stream.hpp"
 
 using namespace boost::mysql::test;
 using boost::mysql::error_code;
@@ -144,7 +142,7 @@ struct boost::mysql::test::test_stream::write_op : boost::asio::coroutine
 
 boost::mysql::test::test_stream::executor_type boost::mysql::test::test_stream::get_executor()
 {
-    return create_tracker_executor(ctx.get_executor(), &executor_info_);
+    return ctx.get_executor();
 }
 
 // Reading

--- a/test/unit/test/detail/engine_impl.cpp
+++ b/test/unit/test/detail/engine_impl.cpp
@@ -27,7 +27,6 @@
 #include <cstring>
 
 #include "test_common/netfun_maker.hpp"
-#include "test_common/tracker_executor.hpp"
 #include "test_unit/printing.hpp"
 
 using namespace boost::mysql::test;
@@ -40,7 +39,6 @@ BOOST_AUTO_TEST_SUITE(test_engine_impl)
 // Satisfies the EngineStream concept
 class mock_engine_stream
 {
-    executor_info stream_executor_info_;
     asio::any_io_executor ex_;
     error_code op_error_;  // Operations complete with this error code
 
@@ -82,7 +80,7 @@ public:
     std::vector<next_action> calls;
 
     mock_engine_stream(asio::any_io_executor ex, error_code op_error = error_code())
-        : ex_(create_tracker_executor(ex, &stream_executor_info_)), op_error_(op_error)
+        : ex_(std::move(ex)), op_error_(op_error)
     {
     }
 


### PR DESCRIPTION
Added the ability to detect the executor call stack and whether we're running from an initiating function or not.
Integration tests now consistently check these two.