### PR TITLE
Fuzzers now run normally and are more resilient to failures

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@
 #
 
 _triggers = { "branch": [ "master", "develop" ] }
-_container_tag = 'b1f46a8305f62d0af54dda34231b199d76e945f1'
+_container_tag = '1e06ba22fc5ab038a3c4ce4a73d0d624848c8f70'
 _win_container_tag = 'e7bd656c3515263f9b3c69a2d73d045f6a0fed72'
 
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,12 +21,12 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/anarthal-containers/build-gcc14:b1f46a8305f62d0af54dda34231b199d76e945f1
+      image: ghcr.io/anarthal-containers/build-gcc14:1e06ba22fc5ab038a3c4ce4a73d0d624848c8f70
       volumes:
         - /var/run/mysqld:/var/run/mysqld
     services:
       mysql:
-        image: ghcr.io/anarthal-containers/ci-db:mysql-8.4.1-b1f46a8305f62d0af54dda34231b199d76e945f1
+        image: ghcr.io/anarthal-containers/ci-db:mysql-8.4.1-1e06ba22fc5ab038a3c4ce4a73d0d624848c8f70
         ports:
           - 3306:3306
         volumes:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -20,12 +20,12 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/anarthal-containers/build-clang18:b1f46a8305f62d0af54dda34231b199d76e945f1
+      image: ghcr.io/anarthal-containers/build-clang18:1e06ba22fc5ab038a3c4ce4a73d0d624848c8f70
       volumes:
         - /var/run/mysqld:/var/run/mysqld
     services:
       mysql:
-        image: ghcr.io/anarthal-containers/ci-db:mysql-8.4.1-b1f46a8305f62d0af54dda34231b199d76e945f1
+        image: ghcr.io/anarthal-containers/ci-db:mysql-8.4.1-1e06ba22fc5ab038a3c4ce4a73d0d624848c8f70
         ports:
           - 3306:3306
         volumes:

--- a/test/fuzzing/Jamfile
+++ b/test/fuzzing/Jamfile
@@ -36,10 +36,11 @@ for local fuzzer in $(all_fuzzers)
     make /tmp/corpus/$(fuzzer) : : common.MkDir ;
     make /tmp/mincorpus/$(fuzzer) : : common.MkDir ;
 
-    # Build the fuzzer
+    # Build the fuzzer. Fail the build if openssl is not found
     exe $(fuzzer)
         : 
             /boost/mysql/test//boost_mysql
+            /boost/mysql/test//fail_if_no_openssl
             $(fuzzer).cpp
         : requirements
             <include>../common/include

--- a/tools/docker/build-clang17.dockerfile
+++ b/tools/docker/build-clang17.dockerfile
@@ -5,7 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-FROM ubuntu:23.10
+FROM ubuntu:24.04
 
 RUN \
     apt-get update && \

--- a/tools/docker/build-clang18.dockerfile
+++ b/tools/docker/build-clang18.dockerfile
@@ -5,13 +5,16 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-FROM ubuntu:23.10
+FROM ubuntu:24.04
 
 RUN \
     apt-get update && \
     apt-get --no-install-recommends -y install \
-        wget \
         ca-certificates \
+        clang-18 \
+        libclang-rt-18-dev \
+        libc++-18-dev \
+        libc++abi-18-dev \
         libssl-dev \
         git \
         ninja-build \
@@ -19,16 +22,5 @@ RUN \
         python3-requests \
         python-is-python3 \
         mysql-client && \
-    echo 'deb http://apt.llvm.org/mantic/ llvm-toolchain-mantic-18 main' > /etc/apt/sources.list.d/llvm.list && \
-    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key > /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
-    apt-get update && \
-    apt-get --no-install-recommends -y install \
-        clang-18 \
-        libclang-rt-18-dev \
-        libc++-18-dev \
-        libc++abi-18-dev && \
-    apt-get -y remove wget && \
-    apt-get -y autoremove && \
     ln -s /usr/bin/clang++-18 /usr/bin/clang++ && \
     ln -s /usr/bin/clang-18 /usr/bin/clang
-

--- a/tools/scripts/build_unix_local.sh
+++ b/tools/scripts/build_unix_local.sh
@@ -12,7 +12,7 @@ repo_base=$(realpath $(dirname $(realpath $0))/../..)
 
 BK=b2
 IMAGE=build-gcc5
-SHA=b1f46a8305f62d0af54dda34231b199d76e945f1
+SHA=1e06ba22fc5ab038a3c4ce4a73d0d624848c8f70
 CONTAINER=builder-$IMAGE
 FULL_IMAGE=ghcr.io/anarthal-containers/$IMAGE:$SHA
 DB=mysql-8.4.1


### PR DESCRIPTION
Updated build-clang17 and build-clang18 to use ubuntu:24.04
Fix missing package in build-clang18
Fuzzers now fail if OpenSSL can't be found

close #323 