### PR TITLE
with_diagnostics now passes through unknown signatures

### DIFF
--- a/example/Jamfile
+++ b/example/Jamfile
@@ -7,8 +7,6 @@
 
 import os ;
 
-project : requirements <library>/boost/mysql//boost_mysql ;
-
 path-constant this_dir : . ;
 
 # The hostname to use for examples

--- a/example/pipeline.cpp
+++ b/example/pipeline.cpp
@@ -55,8 +55,7 @@ asio::awaitable<std::vector<boost::mysql::statement>> batch_prepare(
     for (auto stmt_sql : statements)
         req.add_prepare_statement(stmt_sql);
 
-    // Run the pipeline. Using as_tuple prevents async_run_pipeline from throwing.
-    // This allows us to include the diagnostics object diag in the thrown exception.
+    // Run the pipeline.
     // stage_response is a variant-like type that can hold the response of any stage type.
     std::vector<boost::mysql::stage_response> pipe_res;
     co_await conn.async_run_pipeline(req, pipe_res);

--- a/include/boost/mysql/impl/with_diagnostics.hpp
+++ b/include/boost/mysql/impl/with_diagnostics.hpp
@@ -178,15 +178,15 @@ struct with_diagnostics_async_result<CompletionToken, false, Signatures...>
 
     template <typename Initiation, typename RawCompletionToken, typename... Args>
     static auto initiate(Initiation&& initiation, RawCompletionToken&& token, Args&&... args)
-        -> decltype(async_initiate<
+        -> decltype(asio::async_initiate<
                     maybe_const_token_t<RawCompletionToken>,
                     typename with_diag_signature<Signatures>::type...>(
-            std::declval<with_diag_init<typename std::decay<Initiation>::type>>(),
+            with_diag_init<typename std::decay<Initiation>::type>{std::forward<Initiation>(initiation)},
             access::get_impl(token),
             std::forward<Args>(args)...
         ))
     {
-        return async_initiate<
+        return asio::async_initiate<
             maybe_const_token_t<RawCompletionToken>,
             typename with_diag_signature<Signatures>::type...>(
             with_diag_init<typename std::decay<Initiation>::type>{std::forward<Initiation>(initiation)},
@@ -199,7 +199,7 @@ struct with_diagnostics_async_result<CompletionToken, false, Signatures...>
 // async_result when the signature wasn't modified (pass-through)
 template <typename CompletionToken, typename... Signatures>
 struct with_diagnostics_async_result<CompletionToken, true, Signatures...>
-    : asio::async_result<CompletionToken, typename with_diag_signature<Signatures>::type...>
+    : asio::async_result<CompletionToken, Signatures...>
 {
     template <class RawCompletionToken>
     using maybe_const_token_t = typename std::conditional<
@@ -209,17 +209,13 @@ struct with_diagnostics_async_result<CompletionToken, true, Signatures...>
 
     template <typename Initiation, typename RawCompletionToken, typename... Args>
     static auto initiate(Initiation&& initiation, RawCompletionToken&& token, Args&&... args)
-        -> decltype(async_initiate<
-                    maybe_const_token_t<RawCompletionToken>,
-                    typename with_diag_signature<Signatures>::type...>(
+        -> decltype(asio::async_initiate<maybe_const_token_t<RawCompletionToken>, Signatures...>(
             std::forward<Initiation>(initiation),
             access::get_impl(token),
             std::forward<Args>(args)...
         ))
     {
-        return async_initiate<
-            maybe_const_token_t<RawCompletionToken>,
-            typename with_diag_signature<Signatures>::type...>(
+        return asio::async_initiate<maybe_const_token_t<RawCompletionToken>, Signatures...>(
             std::forward<Initiation>(initiation),
             access::get_impl(token),
             std::forward<Args>(args)...

--- a/include/boost/mysql/impl/with_diagnostics.hpp
+++ b/include/boost/mysql/impl/with_diagnostics.hpp
@@ -50,8 +50,14 @@ struct with_diag_handler_fn
     std::shared_ptr<diagnostics> owning_diag;
 };
 
+// By default, don't modify the signature.
+// This makes asio::as_tuple(with_diagnostics(X)) equivalent
+// to asio::as_tuple(X).
 template <typename Signature>
-struct with_diag_signature;
+struct with_diag_signature
+{
+    using type = Signature;
+};
 
 template <typename R, typename... Args>
 struct with_diag_signature<R(error_code, Args...)>
@@ -146,14 +152,23 @@ struct with_diag_init : public Initiation
     }
 };
 
-}  // namespace detail
-}  // namespace mysql
+// Did with_diagnostics modify any of the signatures?
+// We really support only modifying all or none, and that's enough.
+template <class Signature>
+using with_diag_has_original_signature = std::
+    is_same<Signature, typename with_diag_signature<Signature>::type>;
 
-namespace asio {
+template <class... Signatures>
+using with_diag_has_original_signatures = mp11::
+    mp_all_of<mp11::mp_list<Signatures...>, with_diag_has_original_signature>;
 
+template <typename CompletionToken, bool has_original_signatures, typename... Signatures>
+struct with_diagnostics_async_result;
+
+// async_result when the signature was modified
 template <typename CompletionToken, typename... Signatures>
-struct async_result<mysql::with_diagnostics_t<CompletionToken>, Signatures...>
-    : async_result<CompletionToken, typename mysql::detail::with_diag_signature<Signatures>::type...>
+struct with_diagnostics_async_result<CompletionToken, false, Signatures...>
+    : asio::async_result<CompletionToken, typename with_diag_signature<Signatures>::type...>
 {
     template <class RawCompletionToken>
     using maybe_const_token_t = typename std::conditional<
@@ -165,22 +180,65 @@ struct async_result<mysql::with_diagnostics_t<CompletionToken>, Signatures...>
     static auto initiate(Initiation&& initiation, RawCompletionToken&& token, Args&&... args)
         -> decltype(async_initiate<
                     maybe_const_token_t<RawCompletionToken>,
-                    typename mysql::detail::with_diag_signature<Signatures>::type...>(
-            std::declval<mysql::detail::with_diag_init<typename std::decay<Initiation>::type>>(),
-            mysql::detail::access::get_impl(token),
+                    typename with_diag_signature<Signatures>::type...>(
+            std::declval<with_diag_init<typename std::decay<Initiation>::type>>(),
+            access::get_impl(token),
             std::forward<Args>(args)...
         ))
     {
         return async_initiate<
             maybe_const_token_t<RawCompletionToken>,
-            typename mysql::detail::with_diag_signature<Signatures>::type...>(
-            mysql::detail::with_diag_init<typename std::decay<Initiation>::type>{
-                std::forward<Initiation>(initiation)
-            },
-            mysql::detail::access::get_impl(token),
+            typename with_diag_signature<Signatures>::type...>(
+            with_diag_init<typename std::decay<Initiation>::type>{std::forward<Initiation>(initiation)},
+            access::get_impl(token),
             std::forward<Args>(args)...
         );
     }
+};
+
+// async_result when the signature wasn't modified (pass-through)
+template <typename CompletionToken, typename... Signatures>
+struct with_diagnostics_async_result<CompletionToken, true, Signatures...>
+    : asio::async_result<CompletionToken, typename with_diag_signature<Signatures>::type...>
+{
+    template <class RawCompletionToken>
+    using maybe_const_token_t = typename std::conditional<
+        std::is_const<typename std::remove_reference<RawCompletionToken>::type>::value,
+        const CompletionToken,
+        CompletionToken>::type;
+
+    template <typename Initiation, typename RawCompletionToken, typename... Args>
+    static auto initiate(Initiation&& initiation, RawCompletionToken&& token, Args&&... args)
+        -> decltype(async_initiate<
+                    maybe_const_token_t<RawCompletionToken>,
+                    typename with_diag_signature<Signatures>::type...>(
+            std::forward<Initiation>(initiation),
+            access::get_impl(token),
+            std::forward<Args>(args)...
+        ))
+    {
+        return async_initiate<
+            maybe_const_token_t<RawCompletionToken>,
+            typename with_diag_signature<Signatures>::type...>(
+            std::forward<Initiation>(initiation),
+            access::get_impl(token),
+            std::forward<Args>(args)...
+        );
+    }
+};
+
+}  // namespace detail
+}  // namespace mysql
+
+namespace asio {
+
+template <typename CompletionToken, typename... Signatures>
+struct async_result<mysql::with_diagnostics_t<CompletionToken>, Signatures...>
+    : mysql::detail::with_diagnostics_async_result<
+          CompletionToken,
+          mysql::detail::with_diag_has_original_signatures<Signatures...>::value,
+          Signatures...>
+{
 };
 
 }  // namespace asio

--- a/include/boost/mysql/with_diagnostics.hpp
+++ b/include/boost/mysql/with_diagnostics.hpp
@@ -24,20 +24,26 @@ namespace mysql {
  * Uses knowledge of Boost.MySQL internals to grab any \ref diagnostics
  * that the operation may produce to create a `std::exception_ptr` pointing to an \ref error_with_diagnostics
  * object. On success, the generated `std::exception_ptr` will be `nullptr`.
- * \n
+ *
  * Using `with_diagnostics` to wrap tokens that throw exceptions (like `deferred` + `co_await` or
  * `yield_context`) enhances the thrown exceptions with diagnostics information, matching the ones thrown by
  * sync functions. If you don't use this token, Asio will use `system_error` exceptions, containing less info.
- * \n
+ *
  * This token can only be used with operations involving Boost.MySQL, as it relies on its internals.
- * \n
+ *
  * Like `asio::as_tuple`, this class wraps another completion token. For instance,
  * `with_diagnostics(asio::deferred)` will generate a deferred operation with an adapted
  * signature, which will throw `error_with_diagnostics` when `co_await`'ed.
- * \n
- * This token can only be used for operations with `void(error_code, T...)` signature.
- * If this precondition is broken, a compile-time error will be issued. In particular,
- * `with_diagnostics(asio::as_tuple(X))` is an error.
+ *
+ * If this token is applied to a function with a handler signature that
+ * does not match `void(error_code, T...)`, the token acts as a pass-through:
+ * it does not modify the signature, and calls the underlying token's initiation directly.
+ * This has the following implications:
+ *
+ *   - `asio::as_tuple(with_diagnostics(X))` is equivalent to `asio::as_tuple(X)`.
+ *   - `asio::redirect_error(with_diagnostics(X))` is equivalent to `asio::redirect_error(X)`.
+ *   - Tokens like `asio::as_tuple` and `asio::redirect_error` can be used as partial tokens
+ *     when `with_diagnostics` is the default completion token, as is the case for \ref any_connection.
  */
 template <class CompletionToken>
 class with_diagnostics_t

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -15,8 +15,6 @@ import ac ;
 import indirect ;
 import config : requires ;
 
-project : requirements <library>/boost/mysql//boost_mysql ;
-
 # Support header-only builds
 feature.feature boost.mysql.separate-compilation : on off : propagated composite ;
 
@@ -67,6 +65,7 @@ local requirements =
         <toolset>msvc:<define>_SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING
         <toolset>msvc:<define>_SILENCE_CXX17_ADAPTOR_TYPEDEFS_DEPRECATION_WARNING
         <toolset>msvc:<define>_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING
+        <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS # Required by Asio
         # gcc-13+ doesn't understand view types and issues array bound warnings that don't make sense.
         # -Wno-implicit-fallthrough is required by Asio SSL components
         <toolset>gcc:<cxxflags>"-Wno-dangling-reference -Wno-array-bounds -Wno-implicit-fallthrough"
@@ -90,7 +89,7 @@ local requirements =
 
 alias boost_mysql
     :
-        /boost/charconv//boost_charconv
+        $(boost_dependencies)/<warnings-as-errors>off
         /openssl//ssl/<link>shared
         /openssl//crypto/<link>shared
     : requirements

--- a/test/integration/test/any_connection.cpp
+++ b/test/integration/test/any_connection.cpp
@@ -22,6 +22,7 @@
 
 #include <boost/mysql/impl/internal/variant_stream.hpp>
 
+#include <boost/asio/as_tuple.hpp>
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/cancel_after.hpp>
 #include <boost/asio/co_spawn.hpp>
@@ -316,6 +317,28 @@ BOOST_FIXTURE_TEST_CASE(default_token_cancel_after, any_connection_fixture)
         );
     });
 }
+
+// Using as_tuple as partial token works
+BOOST_FIXTURE_TEST_CASE(default_token_as_tuple, any_connection_fixture)
+{
+    run_coro(ctx, [&]() -> asio::awaitable<void> {
+        // as_tuple works
+        auto [ec] = co_await conn.async_connect(connect_params_builder().build(), asio::as_tuple);
+        BOOST_TEST_REQUIRE(ec == error_code());
+
+        // Returning a value works
+        auto [ec2, stmt] = co_await conn.async_prepare_statement("SELECT ?", asio::as_tuple);
+        BOOST_TEST_REQUIRE(ec2 == error_code());
+        BOOST_TEST(stmt.valid());
+
+        // Error case
+        results result;
+        auto [ec3] = co_await conn.async_execute("SELECT * FROM bad_table", result, asio::as_tuple);
+        BOOST_TEST(ec3 == common_server_errc::er_no_such_table);
+    });
+}
+
+// TODO: redirect_error
 
 // Spotcheck: immediate completions dispatched to the immediate executor
 BOOST_FIXTURE_TEST_CASE(immediate_completions, any_connection_fixture)


### PR DESCRIPTION
This makes asio::as_tuple and asio::redirect_error usable as partial completion tokens with any_connection and connection_pool.
Removed leftover comment in the pipeline example.