### PR TITLE
Updated the coverage build to use gcc-14

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/anarthal-containers/build-gcc13:61b5b771ffefa8c04c43ddc9e023152461a8295f
+      image: ghcr.io/anarthal-containers/build-gcc14:61b5b771ffefa8c04c43ddc9e023152461a8295f
       volumes:
         - /var/run/mysqld:/var/run/mysqld
     services:
@@ -52,8 +52,18 @@ jobs:
         shell: bash
         run: |
           cd ~/boost-root/bin.v2
-          lcov --rc lcov_branch_coverage=0 --gcov-tool gcov-13 --directory . --capture --output-file all.info
-          lcov --rc lcov_branch_coverage=0 --output-file coverage.info --extract all.info '*/boost/mysql*'
+          lcov \
+            --rc branch_coverage=0 \
+            --rc geninfo_unexecuted_blocks=1 \
+            --ignore-errors mismatch \
+            --gcov-tool gcov-14 \
+            --directory . \
+            --capture \
+            --output-file all.info
+          lcov \
+            --rc branch_coverage=0 \
+            --output-file coverage.info \
+            --extract all.info '*/boost/mysql*'
           sed "s|^SF:$HOME/boost-root/|SF:include/|g" coverage.info > $GITHUB_WORKSPACE/coverage.info
       
       - name: Upload coverage reports

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -142,6 +142,7 @@ alias boost_context_lib
     : usage-requirements
         # gcc-14+ seem to enable CET by default, which causes warnings with Boost.Context.
         # Disable CET until https://github.com/boostorg/context/issues/263 gets fixed
+        <toolset>gcc-13:<cxxflags>-fcf-protection=none
         <toolset>gcc-14:<cxxflags>-fcf-protection=none
     ;
 


### PR DESCRIPTION
Workarounds a problem with the build-gcc13 container, which uses a non-LTS Ubuntu release and can't be installed packages