### PR TITLE
Removed the -fcf-protection gcc workaround

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -136,15 +136,7 @@ alias common_test_sources
 
 # Boost.Context causes failures with warnings-as-errors
 # under libc++, because it builds objects that raise a -stdlib=libc++ unused warning
-alias boost_context_lib
-    :
-        /boost/context//boost_context/<warnings-as-errors>off
-    : usage-requirements
-        # gcc-13+ seem to enable CET by default, which causes warnings with Boost.Context.
-        # Disable CET until https://github.com/boostorg/context/issues/263 gets fixed
-        <toolset>gcc-13:<cxxflags>-fcf-protection=none
-        <toolset>gcc-14:<cxxflags>-fcf-protection=none
-    ;
+alias boost_context_lib : /boost/context//boost_context/<warnings-as-errors>off ;
 
 # Beast and JSON depend on Container, which causes trouble with <warnings-as-errors>on
 alias boost_beast_lib : /boost/beast//boost_beast/<warnings-as-errors>off ;


### PR DESCRIPTION
Required because of
https://github.com/boostorg/context/issues/263