### PR TITLE
connection_pool now resizes correctly in the presence of pending connections

### DIFF
--- a/include/boost/mysql/impl/internal/connection_pool/connection_node.hpp
+++ b/include/boost/mysql/impl/internal/connection_pool/connection_node.hpp
@@ -49,8 +49,12 @@ struct conn_shared_state
     asio::basic_waitable_timer<ClockType> idle_connections_cv;
 
     // The number of pending connections (currently getting ready).
-    // Controls that we don't create connections while some are still connecting
+    // Required to compute how many connections we should create at any given point in time.
     std::size_t num_pending_connections{0};
+
+    // The number of async_get_connection ops that are waiting for a connection to become available.
+    // Required to compute how many connections we should create at any given point in time.
+    std::size_t num_pending_requests{0};
 
     // Info about the last connection attempt. Already processed, suitable to be used
     // as the result of an async_get_connection op
@@ -237,8 +241,8 @@ public:
 
     // Not thread-safe
     template <class CompletionToken>
-    auto async_run(CompletionToken&& token
-    ) -> decltype(asio::async_compose<CompletionToken, void(error_code)>(connection_task_op{*this}, token))
+    auto async_run(CompletionToken&& token)
+        -> decltype(asio::async_compose<CompletionToken, void(error_code)>(connection_task_op{*this}, token))
     {
         return asio::async_compose<CompletionToken, void(error_code)>(connection_task_op{*this}, token);
     }

--- a/include/boost/mysql/impl/internal/connection_pool/connection_pool_impl.hpp
+++ b/include/boost/mysql/impl/internal/connection_pool/connection_pool_impl.hpp
@@ -19,6 +19,7 @@
 
 #include <boost/mysql/impl/internal/connection_pool/connection_node.hpp>
 #include <boost/mysql/impl/internal/connection_pool/internal_pool_params.hpp>
+#include <boost/mysql/impl/internal/connection_pool/sansio_connection_node.hpp>
 #include <boost/mysql/impl/internal/coroutine.hpp>
 
 #include <boost/asio/any_completion_handler.hpp>
@@ -97,16 +98,7 @@ class basic_pool_impl
         return static_cast<std::enable_shared_from_this<this_type>*>(this)->shared_from_this();
     }
 
-    // Do we have room for a new connection?
-    // Don't create new connections if we have other connections pending
-    // (i.e. being connected, reset... ) - otherwise pool size increases
-    // for no reason when there is no connectivity.
-    bool can_create_connection() const
-    {
-        return all_conns_.size() < params_.max_size && shared_st_.num_pending_connections == 0u &&
-               state_ == state_t::running;
-    }
-
+    // Create and run one connection
     void create_connection()
     {
         // Connection tasks always run in the pool's executor
@@ -114,10 +106,45 @@ class basic_pool_impl
         all_conns_.back().async_run(asio::bind_executor(pool_ex_, asio::detached));
     }
 
-    void maybe_create_connection()
+    // Create and run n connections
+    void create_connections(std::size_t n)
     {
-        if (can_create_connection())
+        BOOST_ASSERT((all_conns_.size() + n) <= params_.max_size);
+        for (std::size_t i = 0; i < n; ++i)
             create_connection();
+    }
+
+    // Create and run the initial connections
+    void create_initial_connections()
+    {
+        create_connections(num_connections_to_create_initial(
+            params_.initial_size,
+            params_.max_size,
+            shared_st_.num_pending_requests
+        ));
+    }
+
+    // An async_get_connection request is about to wait for an available connection
+    void enter_request_pending()
+    {
+        // Record that we're pending
+        ++shared_st_.num_pending_requests;
+
+        // Create new connections, if required
+        create_connections(num_connections_to_create_running(
+            params_.max_size,
+            all_conns_.size(),
+            shared_st_.num_pending_connections,
+            shared_st_.num_pending_requests
+        ));
+    }
+
+    // An async_get_connection request finished waiting
+    void exit_request_pending()
+    {
+        // Record that we're no longer pending
+        BOOST_ASSERT(shared_st_.num_pending_requests > 0u);
+        --shared_st_.num_pending_requests;
     }
 
     node_type* try_get_connection()
@@ -205,8 +232,7 @@ class basic_pool_impl
                 obj_->state_ = state_t::running;
 
                 // Create the initial connections
-                for (std::size_t i = 0; i < obj_->params_.initial_size; ++i)
-                    obj_->create_connection();
+                obj_->create_initial_connections();
 
                 // Wait for the cancel notification to arrive.
                 BOOST_MYSQL_YIELD(resume_point_, 2, obj_->cancel_timer_.async_wait(std::move(self)))
@@ -334,11 +360,14 @@ class basic_pool_impl
                         break;
                     }
 
-                    // No luck. If there is room for more connections, create one.
-                    obj->maybe_create_connection();
+                    // No luck. Record that we're waiting for a connection.
+                    obj->enter_request_pending();
 
                     // Wait to be notified, or until a cancellation happens
                     BOOST_MYSQL_YIELD(resume_point, 2, obj->wait_for_connections(self))
+
+                    // Record that we're no longer pending
+                    obj->exit_request_pending();
 
                     // Remember that we have waited, so completions are dispatched
                     // correctly

--- a/include/boost/mysql/impl/internal/connection_pool/connection_pool_impl.hpp
+++ b/include/boost/mysql/impl/internal/connection_pool/connection_pool_impl.hpp
@@ -130,8 +130,11 @@ class basic_pool_impl
         // Record that we're pending
         ++shared_st_.num_pending_requests;
 
-        // Create new connections, if required
-        create_connections();
+        // Create new connections, if required.
+        // Don't create any connections if we're not yet running,
+        // since this would leave connections running after run exits
+        if (state_ == state_t::running)
+            create_connections();
     }
 
     // An async_get_connection request finished waiting

--- a/include/boost/mysql/impl/internal/connection_pool/sansio_connection_node.hpp
+++ b/include/boost/mysql/impl/internal/connection_pool/sansio_connection_node.hpp
@@ -14,6 +14,9 @@
 #include <boost/asio/error.hpp>
 #include <boost/assert.hpp>
 
+#include <algorithm>
+#include <cstddef>
+
 namespace boost {
 namespace mysql {
 namespace detail {
@@ -238,6 +241,42 @@ inline diagnostics create_connect_diagnostics(error_code connect_ec, const diagn
         }
     }
     return res;
+}
+
+// Given config params and the current state, computes the number
+// of connections that the pool should create at any given point in time
+inline std::size_t num_connections_to_create_running(
+    std::size_t max_connections,      // config
+    std::size_t current_connections,  // the number of connections in the pool, in any state
+    std::size_t pending_connections,  // the number of connections in the pool in pending state
+    std::size_t pending_requests      // the current number of async_get_connection requests that are waiting
+)
+{
+    // We aim to have one pending connection per pending request.
+    // When these connections successfully connect, they will fulfill the pending requests.
+    std::size_t ideal = pending_requests > pending_connections
+                            ? static_cast<std::size_t>(pending_requests - pending_connections)
+                            : 0u;
+
+    // We can't excess max_connections. This is the room for new connections that we have
+    BOOST_ASSERT(current_connections <= max_connections);
+    std::size_t room = static_cast<std::size_t>(max_connections - current_connections);
+    return (std::min)(ideal, room);
+}
+
+// Given config params and the current state, computes the number
+// of connections that the pool should create when it starts
+inline std::size_t num_connections_to_create_initial(
+    std::size_t min_connections,  // config
+    std::size_t max_connections,  // config
+    std::size_t pending_requests  // the current number of async_get_connection requests that are waiting
+)
+{
+    // When the pool starts, it always has zero connections.
+    // We should create at least min_connections.
+    // If we have pending requests, create at least as many as pending requests we have.
+    // Never exceed the maximum.
+    return (std::min)(max_connections, (std::max)(min_connections, pending_requests));
 }
 
 }  // namespace detail

--- a/include/boost/mysql/impl/internal/connection_pool/sansio_connection_node.hpp
+++ b/include/boost/mysql/impl/internal/connection_pool/sansio_connection_node.hpp
@@ -245,7 +245,8 @@ inline diagnostics create_connect_diagnostics(error_code connect_ec, const diagn
 
 // Given config params and the current state, computes the number
 // of connections that the pool should create at any given point in time
-inline std::size_t num_connections_to_create_running(
+inline std::size_t num_connections_to_create(
+    std::size_t initial_size,         // config
     std::size_t max_size,             // config
     std::size_t current_connections,  // the number of connections in the pool, in any state
     std::size_t pending_connections,  // the number of connections in the pool in pending state
@@ -254,29 +255,21 @@ inline std::size_t num_connections_to_create_running(
 {
     // We aim to have one pending connection per pending request.
     // When these connections successfully connect, they will fulfill the pending requests.
-    std::size_t ideal = pending_requests > pending_connections
-                            ? static_cast<std::size_t>(pending_requests - pending_connections)
-                            : 0u;
+    std::size_t required_by_requests = pending_requests > pending_connections
+                                           ? static_cast<std::size_t>(pending_requests - pending_connections)
+                                           : 0u;
+
+    // We should always have at least min_connections.
+    // This might not be the case if the pool is just starting.
+    std::size_t required_by_min = current_connections < initial_size
+                                      ? static_cast<std::size_t>(initial_size - current_connections)
+                                      : 0u;
 
     // We can't excess max_connections. This is the room for new connections that we have
     BOOST_ASSERT(current_connections <= max_size);
     std::size_t room = static_cast<std::size_t>(max_size - current_connections);
-    return (std::min)(ideal, room);
-}
 
-// Given config params and the current state, computes the number
-// of connections that the pool should create when it starts
-inline std::size_t num_connections_to_create_initial(
-    std::size_t initial_size,     // config
-    std::size_t max_size,         // config
-    std::size_t pending_requests  // the current number of async_get_connection requests that are waiting
-)
-{
-    // When the pool starts, it always has zero connections.
-    // We should create at least min_connections.
-    // If we have pending requests, create at least as many as pending requests we have.
-    // Never exceed the maximum.
-    return (std::min)(max_size, (std::max)(initial_size, pending_requests));
+    return (std::min)((std::max)(required_by_requests, required_by_min), room);
 }
 
 }  // namespace detail

--- a/include/boost/mysql/impl/internal/connection_pool/sansio_connection_node.hpp
+++ b/include/boost/mysql/impl/internal/connection_pool/sansio_connection_node.hpp
@@ -253,6 +253,10 @@ inline std::size_t num_connections_to_create(
     std::size_t pending_requests      // the current number of async_get_connection requests that are waiting
 )
 {
+    BOOST_ASSERT(initial_size <= max_size);
+    BOOST_ASSERT(current_connections <= max_size);
+    BOOST_ASSERT(pending_connections <= current_connections);
+
     // We aim to have one pending connection per pending request.
     // When these connections successfully connect, they will fulfill the pending requests.
     std::size_t required_by_requests = pending_requests > pending_connections
@@ -266,7 +270,6 @@ inline std::size_t num_connections_to_create(
                                       : 0u;
 
     // We can't excess max_connections. This is the room for new connections that we have
-    BOOST_ASSERT(current_connections <= max_size);
     std::size_t room = static_cast<std::size_t>(max_size - current_connections);
 
     return (std::min)((std::max)(required_by_requests, required_by_min), room);

--- a/include/boost/mysql/impl/internal/connection_pool/sansio_connection_node.hpp
+++ b/include/boost/mysql/impl/internal/connection_pool/sansio_connection_node.hpp
@@ -246,7 +246,7 @@ inline diagnostics create_connect_diagnostics(error_code connect_ec, const diagn
 // Given config params and the current state, computes the number
 // of connections that the pool should create at any given point in time
 inline std::size_t num_connections_to_create_running(
-    std::size_t max_connections,      // config
+    std::size_t max_size,             // config
     std::size_t current_connections,  // the number of connections in the pool, in any state
     std::size_t pending_connections,  // the number of connections in the pool in pending state
     std::size_t pending_requests      // the current number of async_get_connection requests that are waiting
@@ -259,16 +259,16 @@ inline std::size_t num_connections_to_create_running(
                             : 0u;
 
     // We can't excess max_connections. This is the room for new connections that we have
-    BOOST_ASSERT(current_connections <= max_connections);
-    std::size_t room = static_cast<std::size_t>(max_connections - current_connections);
+    BOOST_ASSERT(current_connections <= max_size);
+    std::size_t room = static_cast<std::size_t>(max_size - current_connections);
     return (std::min)(ideal, room);
 }
 
 // Given config params and the current state, computes the number
 // of connections that the pool should create when it starts
 inline std::size_t num_connections_to_create_initial(
-    std::size_t min_connections,  // config
-    std::size_t max_connections,  // config
+    std::size_t initial_size,     // config
+    std::size_t max_size,         // config
     std::size_t pending_requests  // the current number of async_get_connection requests that are waiting
 )
 {
@@ -276,7 +276,7 @@ inline std::size_t num_connections_to_create_initial(
     // We should create at least min_connections.
     // If we have pending requests, create at least as many as pending requests we have.
     // Never exceed the maximum.
-    return (std::min)(max_connections, (std::max)(min_connections, pending_requests));
+    return (std::min)(max_size, (std::max)(initial_size, pending_requests));
 }
 
 }  // namespace detail

--- a/test/integration/test/connection_pool.cpp
+++ b/test/integration/test/connection_pool.cpp
@@ -472,7 +472,7 @@ BOOST_DATA_TEST_CASE_F(fixture, pooled_connection_extends_pool_lifetime, data::m
 }
 
 // Having a packaged async_get_connection op extends lifetime
-BOOST_FIXTURE_TEST_CASE(async_get_connection_initation_extends_pool_lifetime, fixture)
+BOOST_FIXTURE_TEST_CASE(async_get_connection_initiation_extends_pool_lifetime, fixture)
 {
     std::unique_ptr<connection_pool> pool(new connection_pool(ctx, create_pool_params()));
 

--- a/test/integration/test/connection_pool.cpp
+++ b/test/integration/test/connection_pool.cpp
@@ -300,7 +300,7 @@ std::int64_t get_connection_id(any_connection& conn)
 {
     results r;
     conn.async_execute("SELECT CONNECTION_ID()", r, as_netresult).validate_no_error();
-    return r.rows().at(0).at(0).as_int64();
+    return r.rows().at(0).at(0).as_uint64();
 }
 
 BOOST_FIXTURE_TEST_CASE(connections_created_if_requests_gt_pending, fixture)

--- a/test/integration/test/connection_pool.cpp
+++ b/test/integration/test/connection_pool.cpp
@@ -315,13 +315,13 @@ BOOST_FIXTURE_TEST_CASE(connections_created_if_requests_gt_pending, fixture)
 
     // Resolve the requests
     auto conn1 = std::move(conn1_result).get();
-    auto conn2 = std::move(conn1_result).get();
-    auto conn3 = std::move(conn1_result).get();
+    auto conn2 = std::move(conn2_result).get();
+    auto conn3 = std::move(conn3_result).get();
 
     // They should be different connections
     auto conn1_id = get_connection_id(conn1.get());
-    auto conn2_id = get_connection_id(conn1.get());
-    auto conn3_id = get_connection_id(conn1.get());
+    auto conn2_id = get_connection_id(conn2.get());
+    auto conn3_id = get_connection_id(conn3.get());
     BOOST_TEST(conn1_id != conn2_id);
     BOOST_TEST(conn1_id != conn3_id);
 

--- a/test/unit/test/connection_pool/connection_pool_impl.cpp
+++ b/test/unit/test/connection_pool/connection_pool_impl.cpp
@@ -1166,6 +1166,20 @@ BOOST_AUTO_TEST_CASE(get_connection_connection_creation)
     BOOST_TEST(fix.pool().nodes().size() == 2u);
 }
 
+BOOST_AUTO_TEST_CASE(get_connection_connections_not_created_if_enough_pending)
+{
+    // Setup
+    pool_params params;
+    params.initial_size = 1;
+    fixture fix(std::move(params));
+    fix.wait_for_num_nodes(1);
+
+    // Create a task. We have already one pending connection, so no node is created
+    auto task = fix.create_task();
+    fix.ctx.poll();
+    BOOST_TEST(fix.pool().nodes().size() == 1u);
+}
+
 BOOST_AUTO_TEST_CASE(get_connection_multiple_requests)
 {
     // Setup

--- a/test/unit/test/connection_pool/connection_pool_impl.cpp
+++ b/test/unit/test/connection_pool/connection_pool_impl.cpp
@@ -254,8 +254,8 @@ public:
     }
 
     template <class CompletionToken>
-    auto async_ping(CompletionToken&& token
-    ) -> decltype(impl_.op_impl(fn_type::ping, nullptr, std::forward<CompletionToken>(token)))
+    auto async_ping(CompletionToken&& token)
+        -> decltype(impl_.op_impl(fn_type::ping, nullptr, std::forward<CompletionToken>(token)))
     {
         return impl_.op_impl(fn_type::ping, nullptr, std::forward<CompletionToken>(token));
     }
@@ -1170,12 +1170,12 @@ BOOST_AUTO_TEST_CASE(get_connection_multiple_requests)
 {
     // Setup
     pool_params params;
-    params.initial_size = 2;
+    params.initial_size = 1;
     params.max_size = 2;
     fixture fix(std::move(params));
 
-    // 2 connection nodes are created from the beginning
-    fix.wait_for_num_nodes(2);
+    // 1 connection node is initially created
+    fix.wait_for_num_nodes(1);
 
     // Issue some parallel requests
     auto task1 = fix.create_task();
@@ -1183,6 +1183,9 @@ BOOST_AUTO_TEST_CASE(get_connection_multiple_requests)
     auto task3 = fix.create_task();
     auto task4 = fix.create_task(nullptr);
     auto task5 = fix.create_task();
+
+    // This should create the other node
+    fix.wait_for_num_nodes(2);
 
     // Two connections can be created. These fulfill two requests
     auto node1 = &fix.pool().nodes().front();

--- a/test/unit/test/connection_pool/sansio_connection_node.cpp
+++ b/test/unit/test/connection_pool/sansio_connection_node.cpp
@@ -30,6 +30,7 @@ namespace asio = boost::asio;
 using detail::collection_state;
 using detail::connection_status;
 using detail::next_connection_action;
+using detail::num_connections_to_create;
 using detail::sansio_connection_node;
 
 BOOST_AUTO_TEST_SUITE(test_sansio_connection_node)
@@ -384,6 +385,60 @@ BOOST_AUTO_TEST_CASE(create_connect_diagnostics_)
             BOOST_TEST(actual == tc.expected);
         }
     }
+}
+
+// Initial cases (when the pool starts running)
+BOOST_AUTO_TEST_CASE(num_connections_to_create_initial)
+{
+    // Order: initial, max, current, pending connections, pending requests
+
+    // default
+    BOOST_TEST(num_connections_to_create(1, 151, 0, 0, 0) == 1u);
+
+    // increased initial_size
+    BOOST_TEST(num_connections_to_create(5, 151, 0, 0, 0) == 5u);
+
+    // initial_size == max_size
+    BOOST_TEST(num_connections_to_create(151, 151, 0, 0, 0) == 151u);
+
+    // with pending requests
+    BOOST_TEST(num_connections_to_create(1, 151, 0, 0, 5) == 5u);
+
+    // with pending requests < initial size
+    BOOST_TEST(num_connections_to_create(6, 151, 0, 0, 5) == 6u);
+
+    // with pending requests > max size
+    BOOST_TEST(num_connections_to_create(5, 151, 0, 0, 200) == 151u);
+}
+
+// Pool resize cases (when the pool is already running, and more connections are required)
+BOOST_AUTO_TEST_CASE(num_connections_to_create_resize)
+{
+    // Order: initial, max, current, pending connections, pending requests
+
+    // all connections are in use
+    BOOST_TEST(num_connections_to_create(1, 151, 1, 0, 1) == 1u);
+    BOOST_TEST(num_connections_to_create(1, 151, 5, 0, 1) == 1u);
+
+    // all connections are in use and there are already requests waiting for pending connections
+    BOOST_TEST(num_connections_to_create(1, 151, 10, 1, 2) == 1u);
+    BOOST_TEST(num_connections_to_create(1, 151, 10, 2, 3) == 1u);
+    BOOST_TEST(num_connections_to_create(1, 151, 10, 2, 5) == 3u);
+
+    // creating connections would exceed the limit
+    BOOST_TEST(num_connections_to_create(1, 151, 149, 0, 3) == 2u);
+    BOOST_TEST(num_connections_to_create(1, 151, 150, 1, 3) == 1u);
+    BOOST_TEST(num_connections_to_create(1, 151, 151, 2, 3) == 0u);
+
+    // there are enough pending connections (e.g. we're struggling to connect)
+    BOOST_TEST(num_connections_to_create(1, 151, 10, 10, 3) == 0u);
+    BOOST_TEST(num_connections_to_create(1, 151, 10, 10, 9) == 0u);
+    BOOST_TEST(num_connections_to_create(1, 151, 10, 10, 10) == 0u);
+
+    // edge case: we don't have the required initial connections created yet
+    BOOST_TEST(num_connections_to_create(10, 151, 3, 0, 2) == 7u);
+    BOOST_TEST(num_connections_to_create(10, 151, 3, 2, 4) == 7u);
+    BOOST_TEST(num_connections_to_create(10, 151, 3, 2, 20) == 18u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Changed the algorithm that calculates how many connections to create to correctly take into account the number of pending requests.
This makes the pool resize as expected and avoids potential deadlocks.

close #395 