### PR TITLE
Connections now check for in-progress async operations and fail without UB

### DIFF
--- a/doc/qbk/04_overview.qbk
+++ b/doc/qbk/04_overview.qbk
@@ -224,17 +224,15 @@ for more info.
 
 [section:async Single outstanding async operation per connection]
 
-At any given point in time, a `any_connection` may only have a single async operation outstanding.
-Because MySQL sessions are stateful, and to keep the implementation simple, messages
-are written to the underlying transport without any locking or queueing.
-If you perform several async operations concurrently on a single connection without any
-serialization, messages from different operations will be interleaved, leading to undefined behavior.
+At any given point in time, an `any_connection` can only have a single async operation outstanding.
+In other words, connections implement no asynchronous locking or queueing, which
+keeps code simple and efficient. If you need to perform several operations in parallel,
+you can open more connections or use [reflink connection_pool].
 
-For example, doing the following is illegal and should be avoided:
+Trying to run operations concurrently on a single connection is detected at
+runtime and generates a `client_errc::operation_in_progress` error:
 
-[overview_async_dont]
-
-If you need to perform queries in parallel, open more connections to the server.
+[overview_async_parallel]
 
 [endsect]
 

--- a/include/boost/mysql/any_connection.hpp
+++ b/include/boost/mysql/any_connection.hpp
@@ -130,6 +130,11 @@ struct any_connection_params
  *
  * This is a move-only type.
  *
+ * \par Single outstanding async operation per connection
+ * At any given point in time, only one async operation can be outstanding
+ * per connection. If an async operation is initiated while another one is in progress,
+ * it will fail with \ref client_errc::operation_in_progress.
+ *
  * \par Default completion tokens
  * The default completion token for all async operations in this class is
  * `with_diagnostics(asio::deferred)`, which allows you to use `co_await`

--- a/include/boost/mysql/client_errc.hpp
+++ b/include/boost/mysql/client_errc.hpp
@@ -139,7 +139,10 @@ enum class client_errc : int
      */
     max_buffer_size_exceeded,
 
-    // TODO: implement in to string and document
+    /**
+     * \brief Another operation is currently in progress for this connection. Make sure
+     * that a single connection does not run two asynchronous operations in parallel.
+     */
     operation_in_progress,
 };
 

--- a/include/boost/mysql/client_errc.hpp
+++ b/include/boost/mysql/client_errc.hpp
@@ -138,6 +138,9 @@ enum class client_errc : int
      * size. Try increasing \ref any_connection_params::max_buffer_size.
      */
     max_buffer_size_exceeded,
+
+    // TODO: implement in to string and document
+    operation_in_progress,
 };
 
 BOOST_MYSQL_DECL

--- a/include/boost/mysql/connection.hpp
+++ b/include/boost/mysql/connection.hpp
@@ -55,6 +55,11 @@ class static_execution_state;
  * the stream using \ref connection::stream, and its executor via \ref connection::get_executor. The
  * executor used by this object is always the same as the underlying stream.
  *
+ * \par Single outstanding async operation per connection
+ * At any given point in time, only one async operation can be outstanding
+ * per connection. If an async operation is initiated while another one is in progress,
+ * it will fail with \ref client_errc::operation_in_progress.
+ *
  * \par Thread safety
  * Distinct objects: safe. \n
  * Shared objects: unsafe. \n

--- a/include/boost/mysql/detail/algo_params.hpp
+++ b/include/boost/mysql/detail/algo_params.hpp
@@ -36,6 +36,8 @@ struct pipeline_request_stage;
 
 struct connect_algo_params
 {
+    const void* server_address;  // Points to an any_address or an endpoint for the corresponding stream. For
+                                 // the templated connection, only valid until the first yield!
     handshake_params hparams;
     bool secure_channel;  // Are we using UNIX sockets or any other secure channel?
 

--- a/include/boost/mysql/detail/any_resumable_ref.hpp
+++ b/include/boost/mysql/detail/any_resumable_ref.hpp
@@ -19,27 +19,31 @@ namespace detail {
 
 class any_resumable_ref
 {
+public:
+    using fn_t = next_action (*)(void*, error_code, std::size_t);
+
+    template <class T, class = typename std::enable_if<!std::is_same<T, any_resumable_ref>::value>::type>
+    explicit any_resumable_ref(T& op) noexcept : algo_(&op), fn_(&do_resume<T>)
+    {
+    }
+
+    // Allow using standalone functions
+    any_resumable_ref(void* algo, fn_t fn) noexcept : algo_(algo), fn_(fn) {}
+
+    next_action resume(error_code ec, std::size_t bytes_transferred)
+    {
+        return fn_(algo_, ec, bytes_transferred);
+    }
+
+private:
     template <class T>
     static next_action do_resume(void* self, error_code ec, std::size_t bytes_transferred)
     {
         return static_cast<T*>(self)->resume(ec, bytes_transferred);
     }
 
-    using fn_t = next_action (*)(void*, error_code, std::size_t);
-
     void* algo_{};
     fn_t fn_{};
-
-public:
-    template <class T, class = typename std::enable_if<!std::is_same<T, any_resumable_ref>::value>::type>
-    explicit any_resumable_ref(T& op) noexcept : algo_(&op), fn_(&do_resume<T>)
-    {
-    }
-
-    next_action resume(error_code ec, std::size_t bytes_transferred)
-    {
-        return fn_(algo_, ec, bytes_transferred);
-    }
 };
 
 }  // namespace detail

--- a/include/boost/mysql/detail/engine.hpp
+++ b/include/boost/mysql/detail/engine.hpp
@@ -25,7 +25,6 @@ public:
     virtual ~engine() {}
     virtual executor_type get_executor() = 0;
     virtual bool supports_ssl() const = 0;
-    virtual void set_endpoint(const void* endpoint) = 0;
     virtual void run(any_resumable_ref resumable, error_code& err) = 0;
     virtual void async_run(any_resumable_ref resumable, asio::any_completion_handler<void(error_code)>) = 0;
 };

--- a/include/boost/mysql/detail/engine_impl.hpp
+++ b/include/boost/mysql/detail/engine_impl.hpp
@@ -111,7 +111,11 @@ struct run_algo_op
                 }
                 else if (act.type() == next_action_type::connect)
                 {
-                    BOOST_MYSQL_YIELD(resume_point_, 6, stream_.async_connect(std::move(self)))
+                    BOOST_MYSQL_YIELD(
+                        resume_point_,
+                        6,
+                        stream_.async_connect(act.connect_endpoint(), std::move(self))
+                    )
                     has_done_io_ = true;
                 }
                 else
@@ -128,7 +132,6 @@ struct run_algo_op
 //    using executor_type = asio::any_io_executor;
 //    executor_type get_executor();
 //    bool supports_ssl() const;
-//    void set_endpoint(const void* endpoint);
 //    std::size_t read_some(asio::mutable_buffer, bool use_ssl, error_code&);
 //    void async_read_some(asio::mutable_buffer, bool use_ssl, CompletinToken&&);
 //    std::size_t write_some(asio::const_buffer, bool use_ssl, error_code&);
@@ -137,8 +140,8 @@ struct run_algo_op
 //    void async_ssl_handshake(CompletionToken&&);
 //    void ssl_shutdown(error_code&);
 //    void async_ssl_shutdown(CompletionToken&&);
-//    void connect(error_code&);
-//    void async_connect(CompletionToken&&);
+//    void connect(const void* server_address, error_code&);
+//    void async_connect(const void* server_address, CompletionToken&&);
 //    void close(error_code&);
 // Async operations are only required to support callback types
 // See stream_adaptor for an implementation
@@ -160,8 +163,6 @@ public:
     executor_type get_executor() override final { return stream_.get_executor(); }
 
     bool supports_ssl() const override final { return stream_.supports_ssl(); }
-
-    void set_endpoint(const void* endpoint) override final { stream_.set_endpoint(endpoint); }
 
     void run(any_resumable_ref resumable, error_code& ec) override final
     {
@@ -207,7 +208,7 @@ public:
             }
             else if (act.type() == next_action_type::connect)
             {
-                stream_.connect(io_ec);
+                stream_.connect(act.connect_endpoint(), io_ec);
             }
             else
             {

--- a/include/boost/mysql/detail/engine_stream_adaptor.hpp
+++ b/include/boost/mysql/detail/engine_stream_adaptor.hpp
@@ -31,61 +31,48 @@ namespace mysql {
 namespace detail {
 
 // Connect and close helpers
-template <class Stream, class = void>
-struct endpoint_storage  // prevent build errors for non socket streams
-{
-    void store(const void*) { BOOST_ASSERT(false); }  // LCOV_EXCL_LINE
-};
-
-template <class Stream>
-struct endpoint_storage<Stream, void_t<typename Stream::lowest_layer_type::endpoint_type>>
-{
-    using endpoint_type = typename Stream::lowest_layer_type::endpoint_type;
-    endpoint_type value;
-    void store(const void* v) { value = *static_cast<const endpoint_type*>(v); }
-};
-
 // LCOV_EXCL_START
 template <class Stream>
-void do_connect_impl(Stream&, const endpoint_storage<Stream>&, error_code&, std::false_type)
+void do_connect_impl(Stream&, const void*, error_code&, std::false_type)
 {
     BOOST_ASSERT(false);
 }
 // LCOV_EXCL_STOP
 
 template <class Stream>
-void do_connect_impl(Stream& stream, const endpoint_storage<Stream>& ep, error_code& ec, std::true_type)
+void do_connect_impl(Stream& stream, const void* ep, error_code& ec, std::true_type)
 {
-    stream.lowest_layer().connect(ep.value, ec);
+    stream.lowest_layer().connect(
+        *static_cast<const typename Stream::lowest_layer_type::endpoint_type*>(ep),
+        ec
+    );
 }
 
 template <class Stream>
-void do_connect(Stream& stream, const endpoint_storage<Stream>& ep, error_code& ec)
+void do_connect(Stream& stream, const void* ep, error_code& ec)
 {
     do_connect_impl(stream, ep, ec, is_socket_stream<Stream>{});
 }
 
 // LCOV_EXCL_START
 template <class Stream, class CompletionToken>
-void do_async_connect_impl(Stream&, const endpoint_storage<Stream>&, CompletionToken&&, std::false_type)
+void do_async_connect_impl(Stream&, const void*, CompletionToken&&, std::false_type)
 {
     BOOST_ASSERT(false);
 }
 // LCOV_EXCL_STOP
 
 template <class Stream, class CompletionToken>
-void do_async_connect_impl(
-    Stream& stream,
-    const endpoint_storage<Stream>& ep,
-    CompletionToken&& token,
-    std::true_type
-)
+void do_async_connect_impl(Stream& stream, const void* ep, CompletionToken&& token, std::true_type)
 {
-    stream.lowest_layer().async_connect(ep.value, std::forward<CompletionToken>(token));
+    stream.lowest_layer().async_connect(
+        *static_cast<const typename Stream::lowest_layer_type::endpoint_type*>(ep),
+        std::forward<CompletionToken>(token)
+    );
 }
 
 template <class Stream, class CompletionToken>
-void do_async_connect(Stream& stream, const endpoint_storage<Stream>& ep, CompletionToken&& token)
+void do_async_connect(Stream& stream, const void* ep, CompletionToken&& token)
 {
     do_async_connect_impl(stream, ep, std::forward<CompletionToken>(token), is_socket_stream<Stream>{});
 }
@@ -115,7 +102,6 @@ template <class Stream>
 class engine_stream_adaptor
 {
     Stream stream_;
-    endpoint_storage<Stream> endpoint_;
 
 public:
     template <class... Args>
@@ -127,8 +113,6 @@ public:
     const Stream& stream() const { return stream_; }
 
     bool supports_ssl() const { return false; }
-
-    void set_endpoint(const void* val) { endpoint_.store(val); }
 
     using executor_type = asio::any_io_executor;
     executor_type get_executor() { return stream_.get_executor(); }
@@ -185,12 +169,12 @@ public:
     }
 
     // Connect and close
-    void connect(error_code& ec) { do_connect(stream_, endpoint_, ec); }
+    void connect(const void* endpoint, error_code& ec) { do_connect(stream_, endpoint, ec); }
 
     template <class CompletionToken>
-    void async_connect(CompletionToken&& token)
+    void async_connect(const void* endpoint, CompletionToken&& token)
     {
-        do_async_connect(stream_, endpoint_, std::forward<CompletionToken>(token));
+        do_async_connect(stream_, endpoint, std::forward<CompletionToken>(token));
     }
 
     void close(error_code& ec) { do_close(stream_, ec); }
@@ -200,7 +184,6 @@ template <class Stream>
 class engine_stream_adaptor<asio::ssl::stream<Stream>>
 {
     asio::ssl::stream<Stream> stream_;
-    endpoint_storage<asio::ssl::stream<Stream>> endpoint_;
 
 public:
     template <class... Args>
@@ -212,8 +195,6 @@ public:
     const asio::ssl::stream<Stream>& stream() const { return stream_; }
 
     bool supports_ssl() const { return true; }
-
-    void set_endpoint(const void* val) { endpoint_.store(val); }
 
     using executor_type = asio::any_io_executor;
     executor_type get_executor() { return stream_.get_executor(); }
@@ -288,12 +269,12 @@ public:
     }
 
     // Connect and close
-    void connect(error_code& ec) { do_connect(stream_, endpoint_, ec); }
+    void connect(const void* endpoint, error_code& ec) { do_connect(stream_, endpoint, ec); }
 
     template <class CompletionToken>
-    void async_connect(CompletionToken&& token)
+    void async_connect(const void* endpoint, CompletionToken&& token)
     {
-        do_async_connect(stream_, endpoint_, std::forward<CompletionToken>(token));
+        do_async_connect(stream_, endpoint, std::forward<CompletionToken>(token));
     }
 
     void close(error_code& ec) { do_close(stream_, ec); }

--- a/include/boost/mysql/detail/next_action.hpp
+++ b/include/boost/mysql/detail/next_action.hpp
@@ -58,6 +58,7 @@ public:
         BOOST_ASSERT(is_done());
         return data_.ec;
     }
+    const void* connect_endpoint() const noexcept { return data_.connect_endpoint; }
     read_args_t read_args() const noexcept
     {
         BOOST_ASSERT(type_ == next_action_type::read);
@@ -69,7 +70,10 @@ public:
         return data_.write_args;
     }
 
-    static next_action connect() noexcept { return next_action(next_action_type::connect, data_t()); }
+    static next_action connect(const void* endpoint) noexcept
+    {
+        return next_action(next_action_type::connect, endpoint);
+    }
     static next_action read(read_args_t args) noexcept { return next_action(next_action_type::read, args); }
     static next_action write(write_args_t args) noexcept
     {
@@ -90,10 +94,12 @@ private:
     union data_t
     {
         error_code ec;
+        const void* connect_endpoint;
         read_args_t read_args;
         write_args_t write_args;
 
         data_t() noexcept : ec(error_code()) {}
+        data_t(const void* endpoint) noexcept : connect_endpoint(endpoint) {}
         data_t(error_code ec) noexcept : ec(ec) {}
         data_t(read_args_t args) noexcept : read_args(args) {}
         data_t(write_args_t args) noexcept : write_args(args) {}

--- a/include/boost/mysql/impl/error_categories.ipp
+++ b/include/boost/mysql/impl/error_categories.ipp
@@ -86,6 +86,9 @@ inline const char* error_to_string(client_errc error)
     case client_errc::max_buffer_size_exceeded:
         return "An operation attempted to read or write a packet larger than the maximum buffer size. "
                "Try increasing any_connection_params::max_buffer_size.";
+    case client_errc::operation_in_progress:
+        return "Another operation is currently in progress for this connection. Make sure that a single "
+               "connection does not run two asynchronous operations in parallel.";
 
     default: return "<unknown MySQL client error>";
     }

--- a/include/boost/mysql/impl/internal/sansio/close_connection.hpp
+++ b/include/boost/mysql/impl/internal/sansio/close_connection.hpp
@@ -24,13 +24,13 @@ namespace detail {
 class close_connection_algo
 {
     int resume_point_{0};
-    quit_connection_algo quit_;
+    quit_connection_algo quit_{{}};
     error_code stored_ec_;
 
 public:
-    close_connection_algo(diagnostics& diag, close_connection_algo_params) noexcept : quit_(diag, {}) {}
+    close_connection_algo(close_connection_algo_params) noexcept {}
 
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         next_action act;
 
@@ -38,15 +38,12 @@ public:
         {
         case 0:
 
-            // Clear diagnostics
-            quit_.diag().clear();
-
             // If we're not connected, we're done
             if (!st.is_connected)
                 return next_action();
 
             // Attempt quit
-            while (!(act = quit_.resume(st, ec)).is_done())
+            while (!(act = quit_.resume(st, diag, ec)).is_done())
                 BOOST_MYSQL_YIELD(resume_point_, 1, act)
             stored_ec_ = act.error();
 

--- a/include/boost/mysql/impl/internal/sansio/connect.hpp
+++ b/include/boost/mysql/impl/internal/sansio/connect.hpp
@@ -29,12 +29,9 @@ class connect_algo
     error_code stored_ec_;
 
 public:
-    connect_algo(diagnostics& diag, connect_algo_params params) noexcept
-        : handshake_(diag, {params.hparams, params.secure_channel})
-    {
-    }
+    connect_algo(connect_algo_params params) noexcept : handshake_({params.hparams, params.secure_channel}) {}
 
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         next_action act;
 
@@ -42,16 +39,13 @@ public:
         {
         case 0:
 
-            // Clear diagnostics
-            handshake_.diag().clear();
-
             // Physical connect
             BOOST_MYSQL_YIELD(resume_point_, 1, next_action::connect())
             if (ec)
                 return ec;
 
             // Handshake
-            while (!(act = handshake_.resume(st, ec)).is_done())
+            while (!(act = handshake_.resume(st, diag, ec)).is_done())
                 BOOST_MYSQL_YIELD(resume_point_, 2, act)
 
             // If handshake failed, close the stream ignoring the result

--- a/include/boost/mysql/impl/internal/sansio/connect.hpp
+++ b/include/boost/mysql/impl/internal/sansio/connect.hpp
@@ -25,11 +25,15 @@ namespace detail {
 class connect_algo
 {
     int resume_point_{0};
+    const void* server_address_;
     handshake_algo handshake_;
     error_code stored_ec_;
 
 public:
-    connect_algo(connect_algo_params params) noexcept : handshake_({params.hparams, params.secure_channel}) {}
+    connect_algo(connect_algo_params params) noexcept
+        : server_address_(params.server_address), handshake_({params.hparams, params.secure_channel})
+    {
+    }
 
     next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
@@ -40,7 +44,7 @@ public:
         case 0:
 
             // Physical connect
-            BOOST_MYSQL_YIELD(resume_point_, 1, next_action::connect())
+            BOOST_MYSQL_YIELD(resume_point_, 1, next_action::connect(server_address_))
             if (ec)
                 return ec;
 

--- a/include/boost/mysql/impl/internal/sansio/connection_state.hpp
+++ b/include/boost/mysql/impl/internal/sansio/connection_state.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_MYSQL_IMPL_INTERNAL_SANSIO_CONNECTION_STATE_HPP
 #define BOOST_MYSQL_IMPL_INTERNAL_SANSIO_CONNECTION_STATE_HPP
 
+#include <boost/mysql/client_errc.hpp>
 #include <boost/mysql/diagnostics.hpp>
 #include <boost/mysql/error_code.hpp>
 #include <boost/mysql/handshake_params.hpp>
@@ -15,6 +16,7 @@
 
 #include <boost/mysql/detail/algo_params.hpp>
 #include <boost/mysql/detail/any_resumable_ref.hpp>
+#include <boost/mysql/detail/next_action.hpp>
 
 #include <boost/mysql/impl/internal/sansio/close_connection.hpp>
 #include <boost/mysql/impl/internal/sansio/close_statement.hpp>
@@ -82,6 +84,14 @@ class connection_state
     connection_state_data st_data_;
     any_algo algo_;
 
+    // A function compatible with any_resumable_ref that always fails immediately
+    // with operation_in_progress. We can't change algo_ while an algorithm is running,
+    // so we need an any_resumable_ref that doesn't point into algo_
+    static next_action fail_op_in_progress(void*, error_code, std::size_t)
+    {
+        return error_code(client_errc::operation_in_progress);
+    }
+
 public:
     // We initialize the algo state with a dummy value. This will be overwritten
     // by setup() before the first algorithm starts running. Doing this avoids
@@ -102,8 +112,16 @@ public:
     template <class AlgoParams>
     any_resumable_ref setup(diagnostics& diag, AlgoParams params)
     {
-        return any_resumable_ref(algo_.emplace<top_level_algo<get_algo_t<AlgoParams>>>(st_data_, diag, params)
-        );
+        // Clear diagnostics
+        diag.clear();
+
+        // If there is an operation in progress, don't change anything, just fail
+        if (st_data_.op_in_progress)
+            return any_resumable_ref(nullptr, &fail_op_in_progress);
+
+        // Emplace the algorithm
+        using algo_type = top_level_algo<get_algo_t<AlgoParams>>;
+        return any_resumable_ref(algo_.emplace<algo_type>(st_data_, diag, params));
     }
 
     any_resumable_ref setup(diagnostics& diag, close_statement_algo_params params)

--- a/include/boost/mysql/impl/internal/sansio/connection_state_data.hpp
+++ b/include/boost/mysql/impl/internal/sansio/connection_state_data.hpp
@@ -40,6 +40,10 @@ enum class ssl_state
 
 struct connection_state_data
 {
+    // Are we currently executing an operation?
+    // Prevent the user from running concurrent operations
+    bool op_in_progress{false};
+
     // Is the connection actually connected? Set by handshake
     bool is_connected{false};
 

--- a/include/boost/mysql/impl/internal/sansio/execute.hpp
+++ b/include/boost/mysql/impl/internal/sansio/execute.hpp
@@ -32,15 +32,14 @@ class read_execute_response_algo
     read_some_rows_algo read_some_rows_st_;
 
 public:
-    read_execute_response_algo(diagnostics& diag, execution_processor* proc) noexcept
-        : read_head_st_(diag, {proc}), read_some_rows_st_(diag, {proc, output_ref()})
+    read_execute_response_algo(execution_processor* proc) noexcept
+        : read_head_st_({proc}), read_some_rows_st_({proc, output_ref()})
     {
     }
 
-    diagnostics& diag() { return read_head_st_.diag(); }
     execution_processor& processor() { return read_head_st_.processor(); }
 
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         next_action act;
 
@@ -53,7 +52,7 @@ public:
                 if (processor().is_reading_head())
                 {
                     read_head_st_.reset();
-                    while (!(act = read_head_st_.resume(st, ec)).is_done())
+                    while (!(act = read_head_st_.resume(st, diag, ec)).is_done())
                         BOOST_MYSQL_YIELD(resume_point_, 1, act)
                     if (act.error())
                         return act;
@@ -61,7 +60,7 @@ public:
                 else if (processor().is_reading_rows())
                 {
                     read_some_rows_st_.reset();
-                    while (!(act = read_some_rows_st_.resume(st, ec)).is_done())
+                    while (!(act = read_some_rows_st_.resume(st, diag, ec)).is_done())
                         BOOST_MYSQL_YIELD(resume_point_, 2, act)
                     if (act.error())
                         return act;
@@ -79,16 +78,15 @@ class execute_algo
     start_execution_algo start_execution_st_;
     read_execute_response_algo read_response_st_;
 
-    diagnostics& diag() { return read_response_st_.diag(); }
     execution_processor& processor() { return read_response_st_.processor(); }
 
 public:
-    execute_algo(diagnostics& diag, execute_algo_params params) noexcept
-        : start_execution_st_(diag, {params.req, params.proc}), read_response_st_(diag, params.proc)
+    execute_algo(execute_algo_params params) noexcept
+        : start_execution_st_({params.req, params.proc}), read_response_st_(params.proc)
     {
     }
 
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         next_action act;
 
@@ -97,13 +95,13 @@ public:
         case 0:
 
             // Send request and read the first response
-            while (!(act = start_execution_st_.resume(st, ec)).is_done())
+            while (!(act = start_execution_st_.resume(st, diag, ec)).is_done())
                 BOOST_MYSQL_YIELD(resume_point_, 1, act)
             if (act.error())
                 return act;
 
             // Read anything else
-            while (!(act = read_response_st_.resume(st, ec)).is_done())
+            while (!(act = read_response_st_.resume(st, diag, ec)).is_done())
                 BOOST_MYSQL_YIELD(resume_point_, 2, act)
             return act;
         }

--- a/include/boost/mysql/impl/internal/sansio/handshake.hpp
+++ b/include/boost/mysql/impl/internal/sansio/handshake.hpp
@@ -68,7 +68,6 @@ inline error_code process_capabilities(
 class handshake_algo
 {
     int resume_point_{0};
-    diagnostics* diag_;
     handshake_params hparams_;
     auth_response auth_resp_;
     std::uint8_t sequence_number_{0};
@@ -92,11 +91,15 @@ class handshake_algo
     // Once the handshake is processed, the capabilities are stored in the connection state
     bool use_ssl(const connection_state_data& st) const { return st.current_capabilities.has(CLIENT_SSL); }
 
-    error_code process_handshake(connection_state_data& st, span<const std::uint8_t> buffer)
+    error_code process_handshake(
+        connection_state_data& st,
+        diagnostics& diag,
+        span<const std::uint8_t> buffer
+    )
     {
         // Deserialize server hello
         server_hello hello{};
-        auto err = deserialize_server_hello(buffer, hello, *diag_);
+        auto err = deserialize_server_hello(buffer, hello, diag);
         if (err)
             return err;
 
@@ -193,14 +196,12 @@ class handshake_algo
     }
 
 public:
-    handshake_algo(diagnostics& diag, handshake_algo_params params) noexcept
-        : diag_(&diag), hparams_(params.hparams), secure_channel_(params.secure_channel)
+    handshake_algo(handshake_algo_params params) noexcept
+        : hparams_(params.hparams), secure_channel_(params.secure_channel)
     {
     }
 
-    diagnostics& diag() { return *diag_; }
-
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         if (ec)
             return ec;
@@ -212,14 +213,13 @@ public:
         case 0:
 
             // Setup
-            diag_->clear();
             st.reset();
 
             // Read server greeting
             BOOST_MYSQL_YIELD(resume_point_, 1, st.read(sequence_number_))
 
             // Process server greeting
-            ec = process_handshake(st, st.reader.message());
+            ec = process_handshake(st, diag, st.reader.message());
             if (ec)
                 return ec;
 
@@ -246,7 +246,7 @@ public:
                 BOOST_MYSQL_YIELD(resume_point_, 5, st.read(sequence_number_))
 
                 // Process it
-                resp = deserialize_handshake_server_response(st.reader.message(), st.flavor, *diag_);
+                resp = deserialize_handshake_server_response(st.reader.message(), st.flavor, diag);
                 if (resp.type == handhake_server_response::type_t::ok)
                 {
                     // Auth success, quit

--- a/include/boost/mysql/impl/internal/sansio/ping.hpp
+++ b/include/boost/mysql/impl/internal/sansio/ping.hpp
@@ -8,6 +8,8 @@
 #ifndef BOOST_MYSQL_IMPL_INTERNAL_SANSIO_PING_HPP
 #define BOOST_MYSQL_IMPL_INTERNAL_SANSIO_PING_HPP
 
+#include <boost/mysql/diagnostics.hpp>
+
 #include <boost/mysql/detail/algo_params.hpp>
 
 #include <boost/mysql/impl/internal/coroutine.hpp>
@@ -21,15 +23,12 @@ namespace detail {
 class read_ping_response_algo
 {
     int resume_point_{0};
-    diagnostics* diag_;
     std::uint8_t seqnum_{0};
 
 public:
-    read_ping_response_algo(diagnostics& diag, std::uint8_t seqnum) noexcept : diag_(&diag), seqnum_(seqnum)
-    {
-    }
+    read_ping_response_algo(std::uint8_t seqnum) noexcept : seqnum_(seqnum) {}
 
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         switch (resume_point_)
         {
@@ -41,7 +40,7 @@ public:
                 return ec;
 
             // Process the OK packet and done
-            ec = st.deserialize_ok(*diag_);
+            ec = st.deserialize_ok(diag);
         }
 
         return ec;

--- a/include/boost/mysql/impl/internal/sansio/prepare_statement.hpp
+++ b/include/boost/mysql/impl/internal/sansio/prepare_statement.hpp
@@ -26,15 +26,14 @@ namespace detail {
 class read_prepare_statement_response_algo
 {
     int resume_point_{0};
-    diagnostics* diag_;
     std::uint8_t sequence_number_{0};
     unsigned remaining_meta_{0};
     statement res_;
 
-    error_code process_response(connection_state_data& st)
+    error_code process_response(connection_state_data& st, diagnostics& diag)
     {
         prepare_stmt_response response{};
-        auto err = deserialize_prepare_stmt_response(st.reader.message(), st.flavor, response, *diag_);
+        auto err = deserialize_prepare_stmt_response(st.reader.message(), st.flavor, response, diag);
         if (err)
             return err;
         res_ = access::construct<statement>(response.id, response.num_params);
@@ -43,15 +42,11 @@ class read_prepare_statement_response_algo
     }
 
 public:
-    read_prepare_statement_response_algo(diagnostics& diag, std::uint8_t seqnum) noexcept
-        : diag_(&diag), sequence_number_(seqnum)
-    {
-    }
+    read_prepare_statement_response_algo(std::uint8_t seqnum) noexcept : sequence_number_(seqnum) {}
 
     std::uint8_t& sequence_number() { return sequence_number_; }
-    diagnostics& diag() { return *diag_; }
 
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         if (ec)
             return ec;
@@ -66,7 +61,7 @@ public:
             BOOST_MYSQL_YIELD(resume_point_, 1, st.read(sequence_number_))
 
             // Process response
-            ec = process_response(st);
+            ec = process_response(st, diag);
             if (ec)
                 return ec;
 
@@ -89,21 +84,18 @@ class prepare_statement_algo
     string_view stmt_sql_;
 
 public:
-    prepare_statement_algo(diagnostics& diag, prepare_statement_algo_params params) noexcept
-        : read_response_st_(diag, 0u), stmt_sql_(params.stmt_sql)
+    prepare_statement_algo(prepare_statement_algo_params params) noexcept
+        : read_response_st_(0u), stmt_sql_(params.stmt_sql)
     {
     }
 
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         next_action act;
 
         switch (resume_point_)
         {
         case 0:
-
-            // Clear diagnostics
-            read_response_st_.diag().clear();
 
             // Send request
             BOOST_MYSQL_YIELD(
@@ -115,7 +107,7 @@ public:
                 return ec;
 
             // Read response
-            while (!(act = read_response_st_.resume(st, ec)).is_done())
+            while (!(act = read_response_st_.resume(st, diag, ec)).is_done())
                 BOOST_MYSQL_YIELD(resume_point_, 2, act)
             return act;
         }

--- a/include/boost/mysql/impl/internal/sansio/quit_connection.hpp
+++ b/include/boost/mysql/impl/internal/sansio/quit_connection.hpp
@@ -25,22 +25,16 @@ namespace detail {
 class quit_connection_algo
 {
     int resume_point_{0};
-    diagnostics* diag_;
     std::uint8_t sequence_number_{0};
 
 public:
-    quit_connection_algo(diagnostics& diag, quit_connection_algo_params) noexcept : diag_(&diag) {}
+    quit_connection_algo(quit_connection_algo_params) noexcept {}
 
-    diagnostics& diag() { return *diag_; }
-
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics&, error_code ec)
     {
         switch (resume_point_)
         {
         case 0:
-
-            // Clear diagnostics
-            diag_->clear();
 
             // Send quit message
             BOOST_MYSQL_YIELD(resume_point_, 1, st.write(quit_command(), sequence_number_))

--- a/include/boost/mysql/impl/internal/sansio/read_resultset_head.hpp
+++ b/include/boost/mysql/impl/internal/sansio/read_resultset_head.hpp
@@ -60,7 +60,6 @@ inline error_code process_field_definition(
 
 class read_resultset_head_algo
 {
-    diagnostics* diag_;
     execution_processor* proc_;
 
     struct state_t
@@ -69,17 +68,13 @@ class read_resultset_head_algo
     } state_;
 
 public:
-    read_resultset_head_algo(diagnostics& diag, read_resultset_head_algo_params params) noexcept
-        : diag_(&diag), proc_(params.proc)
-    {
-    }
+    read_resultset_head_algo(read_resultset_head_algo_params params) noexcept : proc_(params.proc) {}
 
     void reset() { state_ = state_t{}; }
 
-    diagnostics& diag() { return *diag_; }
     execution_processor& processor() { return *proc_; }
 
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         if (ec)
             return ec;
@@ -87,9 +82,6 @@ public:
         switch (state_.resume_point)
         {
         case 0:
-
-            // Clear diagnostics
-            diag_->clear();
 
             // If we're not reading head, return
             if (!proc_->is_reading_head())
@@ -100,7 +92,7 @@ public:
 
             // Response may be: ok_packet, err_packet, local infile request
             // (not implemented), or response with fields
-            ec = process_execution_response(st, *proc_, st.reader.message(), *diag_);
+            ec = process_execution_response(st, *proc_, st.reader.message(), diag);
             if (ec)
                 return ec;
 
@@ -111,7 +103,7 @@ public:
                 BOOST_MYSQL_YIELD(state_.resume_point, 2, st.read(proc_->sequence_number()))
 
                 // Process the metadata packet
-                ec = process_field_definition(*proc_, st.reader.message(), *diag_);
+                ec = process_field_definition(*proc_, st.reader.message(), diag);
                 if (ec)
                     return ec;
             }

--- a/include/boost/mysql/impl/internal/sansio/read_some_rows.hpp
+++ b/include/boost/mysql/impl/internal/sansio/read_some_rows.hpp
@@ -27,7 +27,6 @@ namespace detail {
 
 class read_some_rows_algo
 {
-    diagnostics* diag_;
     execution_processor* proc_;
     output_ref output_;
 
@@ -94,8 +93,8 @@ class read_some_rows_algo
     }
 
 public:
-    read_some_rows_algo(diagnostics& diag, read_some_rows_algo_params params) noexcept
-        : diag_(&diag), proc_(params.proc), output_(params.output)
+    read_some_rows_algo(read_some_rows_algo_params params) noexcept
+        : proc_(params.proc), output_(params.output)
     {
     }
 
@@ -104,7 +103,7 @@ public:
     const execution_processor& processor() const { return *proc_; }
     execution_processor& processor() { return *proc_; }
 
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         if (ec)
             return ec;
@@ -112,9 +111,6 @@ public:
         switch (state_.resume_point)
         {
         case 0:
-
-            // Clear diagnostics
-            diag_->clear();
 
             // Clear any previous use of shared fields.
             // Required for the dynamic version to work.
@@ -129,7 +125,7 @@ public:
             BOOST_MYSQL_YIELD(state_.resume_point, 1, st.read(proc_->sequence_number(), true))
 
             // Process messages
-            std::tie(ec, state_.rows_read) = process_some_rows(st, *proc_, output_, *diag_);
+            std::tie(ec, state_.rows_read) = process_some_rows(st, *proc_, output_, diag);
             return ec;
         }
 

--- a/include/boost/mysql/impl/internal/sansio/read_some_rows_dynamic.hpp
+++ b/include/boost/mysql/impl/internal/sansio/read_some_rows_dynamic.hpp
@@ -8,7 +8,6 @@
 #ifndef BOOST_MYSQL_IMPL_INTERNAL_SANSIO_READ_SOME_ROWS_DYNAMIC_HPP
 #define BOOST_MYSQL_IMPL_INTERNAL_SANSIO_READ_SOME_ROWS_DYNAMIC_HPP
 
-#include <boost/mysql/diagnostics.hpp>
 #include <boost/mysql/error_code.hpp>
 #include <boost/mysql/rows_view.hpp>
 
@@ -29,8 +28,8 @@ namespace detail {
 class read_some_rows_dynamic_algo : public read_some_rows_algo
 {
 public:
-    read_some_rows_dynamic_algo(diagnostics& diag, read_some_rows_dynamic_algo_params params) noexcept
-        : read_some_rows_algo(diag, read_some_rows_algo_params{params.exec_st, output_ref()})
+    read_some_rows_dynamic_algo(read_some_rows_dynamic_algo_params params) noexcept
+        : read_some_rows_algo(read_some_rows_algo_params{params.exec_st, output_ref()})
     {
     }
 

--- a/include/boost/mysql/impl/internal/sansio/reset_connection.hpp
+++ b/include/boost/mysql/impl/internal/sansio/reset_connection.hpp
@@ -25,16 +25,12 @@ namespace detail {
 class read_reset_connection_response_algo
 {
     int resume_point_{0};
-    diagnostics* diag_;
     std::uint8_t seqnum_{0};
 
 public:
-    read_reset_connection_response_algo(diagnostics& diag, std::uint8_t seqnum) noexcept
-        : diag_(&diag), seqnum_(seqnum)
-    {
-    }
+    read_reset_connection_response_algo(std::uint8_t seqnum) noexcept : seqnum_(seqnum) {}
 
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         switch (resume_point_)
         {
@@ -46,7 +42,7 @@ public:
                 return ec;
 
             // Verify it's what we expected
-            ec = st.deserialize_ok(*diag_);
+            ec = st.deserialize_ok(diag);
             if (!ec)
             {
                 // Reset was successful. Resetting changes the connection's character set

--- a/include/boost/mysql/impl/internal/sansio/run_pipeline.hpp
+++ b/include/boost/mysql/impl/internal/sansio/run_pipeline.hpp
@@ -50,7 +50,6 @@ class run_pipeline_algo
         any_read_algo() noexcept : nothing{} {}
     };
 
-    diagnostics* diag_;
     span<const std::uint8_t> request_buffer_;
     span<const pipeline_request_stage> stages_;
     std::vector<stage_response>* response_;
@@ -98,23 +97,23 @@ class run_pipeline_algo
             auto& processor = access::get_impl((*response_)[current_stage_index_]).get_processor();
             processor.reset(stage.stage_specific.enc, st.meta_mode);
             processor.sequence_number() = stage.seqnum;
-            read_response_algo_.execute = {temp_diag_, &processor};
+            read_response_algo_.execute = {&processor};
             break;
         }
         case pipeline_stage_kind::prepare_statement:
-            read_response_algo_.prepare_statement = {temp_diag_, stage.seqnum};
+            read_response_algo_.prepare_statement = {stage.seqnum};
             break;
         case pipeline_stage_kind::close_statement:
             // Close statement doesn't have a response
             read_response_algo_.nothing = nullptr;
             break;
         case pipeline_stage_kind::set_character_set:
-            read_response_algo_.set_character_set = {temp_diag_, stage.stage_specific.charset, stage.seqnum};
+            read_response_algo_.set_character_set = {stage.stage_specific.charset, stage.seqnum};
             break;
         case pipeline_stage_kind::reset_connection:
-            read_response_algo_.reset_connection = {temp_diag_, stage.seqnum};
+            read_response_algo_.reset_connection = {stage.seqnum};
             break;
-        case pipeline_stage_kind::ping: read_response_algo_.ping = {temp_diag_, stage.seqnum}; break;
+        case pipeline_stage_kind::ping: read_response_algo_.ping = {stage.seqnum}; break;
         default: BOOST_ASSERT(false);  // LCOV_EXCL_LINE
         }
     }
@@ -127,7 +126,7 @@ class run_pipeline_algo
         }
     }
 
-    void on_stage_finished(const connection_state_data& st, error_code stage_ec)
+    void on_stage_finished(const connection_state_data& st, diagnostics& output_diag, error_code stage_ec)
     {
         if (stage_ec)
         {
@@ -136,14 +135,14 @@ class run_pipeline_algo
             if (is_fatal_error(stage_ec))
             {
                 pipeline_ec_ = stage_ec;
-                *diag_ = temp_diag_;
+                output_diag = temp_diag_;
                 has_hatal_error_ = true;
             }
             else if (!pipeline_ec_)
             {
                 // In the absence of fatal errors, the first error we encounter is the result of the operation
                 pipeline_ec_ = stage_ec;
-                *diag_ = temp_diag_;
+                output_diag = temp_diag_;
             }
 
             // Propagate the error
@@ -168,29 +167,26 @@ class run_pipeline_algo
     {
         switch (stages_[current_stage_index_].kind)
         {
-        case pipeline_stage_kind::execute: return read_response_algo_.execute.resume(st, ec);
+        case pipeline_stage_kind::execute: return read_response_algo_.execute.resume(st, temp_diag_, ec);
         case pipeline_stage_kind::prepare_statement:
-            return read_response_algo_.prepare_statement.resume(st, ec);
+            return read_response_algo_.prepare_statement.resume(st, temp_diag_, ec);
         case pipeline_stage_kind::reset_connection:
-            return read_response_algo_.reset_connection.resume(st, ec);
+            return read_response_algo_.reset_connection.resume(st, temp_diag_, ec);
         case pipeline_stage_kind::set_character_set:
-            return read_response_algo_.set_character_set.resume(st, ec);
-        case pipeline_stage_kind::ping: return read_response_algo_.ping.resume(st, ec);
+            return read_response_algo_.set_character_set.resume(st, temp_diag_, ec);
+        case pipeline_stage_kind::ping: return read_response_algo_.ping.resume(st, temp_diag_, ec);
         case pipeline_stage_kind::close_statement: return next_action();  // has no response
         default: BOOST_ASSERT(false); return next_action();               // LCOV_EXCL_LINE
         }
     }
 
 public:
-    run_pipeline_algo(diagnostics& diag, run_pipeline_algo_params params) noexcept
-        : diag_(&diag),
-          request_buffer_(params.request_buffer),
-          stages_(params.request_stages),
-          response_(params.response)
+    run_pipeline_algo(run_pipeline_algo_params params) noexcept
+        : request_buffer_(params.request_buffer), stages_(params.request_stages), response_(params.response)
     {
     }
 
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         next_action act;
 
@@ -199,7 +195,6 @@ public:
         case 0:
 
             // Clear previous state
-            diag_->clear();
             setup_response();
 
             // If the request is empty, don't do anything
@@ -222,7 +217,7 @@ public:
                 // If there was a fatal error, just set the error and move forward
                 if (has_hatal_error_)
                 {
-                    set_stage_error(pipeline_ec_, diagnostics(*diag_));
+                    set_stage_error(pipeline_ec_, diagnostics(diag));
                     continue;
                 }
 
@@ -235,7 +230,7 @@ public:
                     BOOST_MYSQL_YIELD(resume_point_, 2, act)
 
                 // Process the stage's result
-                on_stage_finished(st, act.error());
+                on_stage_finished(st, diag, act.error());
             }
         }
 

--- a/include/boost/mysql/impl/internal/sansio/set_character_set.hpp
+++ b/include/boost/mysql/impl/internal/sansio/set_character_set.hpp
@@ -44,20 +44,18 @@ inline system::result<std::string> compose_set_names(character_set charset)
 class read_set_character_set_response_algo
 {
     int resume_point_{0};
-    diagnostics* diag_;
     character_set charset_;
     std::uint8_t seqnum_{0};
 
 public:
-    read_set_character_set_response_algo(diagnostics& diag, character_set charset, std::uint8_t seqnum)
-        : diag_(&diag), charset_(charset), seqnum_(seqnum)
+    read_set_character_set_response_algo(character_set charset, std::uint8_t seqnum)
+        : charset_(charset), seqnum_(seqnum)
     {
     }
     character_set charset() const { return charset_; }
-    diagnostics& diag() { return *diag_; }
     std::uint8_t& sequence_number() { return seqnum_; }
 
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         // SET NAMES never returns rows. Using execute requires us to allocate
         // a results object, which we can avoid by simply sending the query and reading the OK response.
@@ -71,7 +69,7 @@ public:
                 return ec;
 
             // Verify it's what we expected
-            ec = st.deserialize_ok(*diag_);
+            ec = st.deserialize_ok(diag);
             if (ec)
                 return ec;
 
@@ -97,12 +95,12 @@ class set_character_set_algo
     }
 
 public:
-    set_character_set_algo(diagnostics& diag, set_character_set_algo_params params) noexcept
-        : read_response_st_(diag, params.charset, 0u)
+    set_character_set_algo(set_character_set_algo_params params) noexcept
+        : read_response_st_(params.charset, 0u)
     {
     }
 
-    next_action resume(connection_state_data& st, error_code ec)
+    next_action resume(connection_state_data& st, diagnostics& diag, error_code ec)
     {
         next_action act;
 
@@ -112,16 +110,13 @@ public:
         {
         case 0:
 
-            // Setup
-            read_response_st_.diag().clear();
-
             // Send the execution request
             BOOST_MYSQL_YIELD(resume_point_, 1, compose_request(st))
             if (ec)
                 return ec;
 
             // Read the response
-            while (!(act = read_response_st_.resume(st, ec)).is_done())
+            while (!(act = read_response_st_.resume(st, diag, ec)).is_done())
                 BOOST_MYSQL_YIELD(resume_point_, 2, act)
             return act;
         }

--- a/include/boost/mysql/impl/internal/sansio/top_level_algo.hpp
+++ b/include/boost/mysql/impl/internal/sansio/top_level_algo.hpp
@@ -66,6 +66,12 @@ public:
         switch (resume_point_)
         {
         case 0:
+            // Check that we're not already running something
+            if (st_->op_in_progress)
+                return error_code(client_errc::operation_in_progress);
+
+            // Mark that we're running an operation
+            st_->op_in_progress = true;
 
             // Run until completion
             while (true)
@@ -76,6 +82,10 @@ public:
                 // Check next action
                 if (act.is_done())
                 {
+                    // Record that we're no longer running an operation
+                    st_->op_in_progress = false;
+
+                    // Done
                     return act;
                 }
                 else if (act.type() == next_action_type::read)

--- a/include/boost/mysql/impl/internal/sansio/top_level_algo.hpp
+++ b/include/boost/mysql/impl/internal/sansio/top_level_algo.hpp
@@ -9,12 +9,14 @@
 #define BOOST_MYSQL_IMPL_INTERNAL_SANSIO_TOP_LEVEL_ALGO_HPP
 
 #include <boost/mysql/client_errc.hpp>
+#include <boost/mysql/diagnostics.hpp>
 #include <boost/mysql/error_code.hpp>
 
 #include <boost/mysql/detail/next_action.hpp>
 
 #include <boost/mysql/impl/internal/coroutine.hpp>
 #include <boost/mysql/impl/internal/sansio/connection_state_data.hpp>
+#include <boost/mysql/impl/internal/sansio/run_pipeline.hpp>
 
 #include <boost/core/span.hpp>
 
@@ -48,12 +50,14 @@ class top_level_algo
 {
     int resume_point_{0};
     connection_state_data* st_;
+    diagnostics* diag_;
     InnerAlgo algo_;
     span<const std::uint8_t> bytes_to_write_;
 
 public:
     template <class... Args>
-    top_level_algo(connection_state_data& st, Args&&... args) : st_(&st), algo_(std::forward<Args>(args)...)
+    top_level_algo(connection_state_data& st, diagnostics& diag, Args&&... args)
+        : st_(&st), diag_(&diag), algo_(std::forward<Args>(args)...)
     {
     }
 
@@ -66,18 +70,17 @@ public:
         switch (resume_point_)
         {
         case 0:
-            // Check that we're not already running something
-            if (st_->op_in_progress)
-                return error_code(client_errc::operation_in_progress);
-
-            // Mark that we're running an operation
+            // We shouldn't be running another operation if we get here
+            // (caught by setup).
+            // Record that we're running an operation
+            BOOST_ASSERT(!st_->op_in_progress);
             st_->op_in_progress = true;
 
             // Run until completion
             while (true)
             {
                 // Run the op
-                act = algo_.resume(*st_, ec);
+                act = algo_.resume(*st_, *diag_, ec);
 
                 // Check next action
                 if (act.is_done())

--- a/include/boost/mysql/impl/internal/variant_stream.hpp
+++ b/include/boost/mysql/impl/internal/variant_stream.hpp
@@ -183,8 +183,6 @@ public:
 
     bool supports_ssl() const { return true; }
 
-    void set_endpoint(const void* value) { address_ = static_cast<const any_address*>(value); }
-
     // Executor
     using executor_type = asio::any_io_executor;
     executor_type get_executor() { return st_.sock.get_executor(); }
@@ -272,10 +270,10 @@ public:
     }
 
     // Connect and close
-    void connect(error_code& output_ec)
+    void connect(const void* server_address, error_code& output_ec)
     {
         // Setup
-        variant_stream_connect_algo algo(st_, *address_);
+        variant_stream_connect_algo algo(st_, *static_cast<const any_address*>(server_address));
         error_code ec;
         asio::ip::tcp::resolver::results_type resolver_results;
 
@@ -298,9 +296,13 @@ public:
     }
 
     template <class CompletionToken>
-    void async_connect(CompletionToken&& token)
+    void async_connect(const void* server_address, CompletionToken&& token)
     {
-        asio::async_compose<CompletionToken, void(error_code)>(connect_op(*this), token, get_executor());
+        asio::async_compose<CompletionToken, void(error_code)>(
+            connect_op(*this, *static_cast<const any_address*>(server_address)),
+            token,
+            get_executor()
+        );
     }
 
     void close(error_code& ec)
@@ -313,15 +315,14 @@ public:
     const asio::generic::stream_protocol::socket& socket() const { return st_.sock; }
 
 private:
-    const any_address* address_{};
     variant_stream_state st_;
 
     struct connect_op
     {
         std::unique_ptr<variant_stream_connect_algo> algo_;
 
-        connect_op(variant_stream& this_obj)
-            : algo_(new variant_stream_connect_algo(this_obj.st_, *this_obj.address_))
+        connect_op(variant_stream& this_obj, const any_address& server_address)
+            : algo_(new variant_stream_connect_algo(this_obj.st_, server_address))
         {
         }
 

--- a/test/common/src/utils.cpp
+++ b/test/common/src/utils.cpp
@@ -401,7 +401,7 @@ void boost::mysql::test::poll_until(
         ctx.restart();
 
         // Poll until this time point
-        constexpr std::chrono::seconds timeout(5);
+        constexpr std::chrono::seconds timeout(15);
         auto timeout_tp = steady_clock::now() + timeout;
 
         // Perform the polling

--- a/test/integration/db_setup.sql
+++ b/test/integration/db_setup.sql
@@ -68,10 +68,6 @@ INSERT INTO multifield_table VALUES
     (1, "aaa", 11, 1.1, 0.1),
     (2, "bbb", 22, NULL, 0.2);
 
-CREATE TABLE locks_table(
-    id INT NOT NULL PRIMARY KEY AUTO_INCREMENT
-);
-
 -- Tables to test we retrieve correctly values of every possible type
 -- Every type gets a separate table. Each field within the table is a possible variant of this same type
 -- Every row is a test case, identified by the id column.

--- a/test/integration/db_setup.sql
+++ b/test/integration/db_setup.sql
@@ -513,6 +513,22 @@ GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
 -- Stored procedures
 DELIMITER //
 
+CREATE PROCEDURE get_lock_checked(
+    IN lock_name VARCHAR(255),
+    IN timeout_seconds INT
+)
+BEGIN
+    DECLARE lock_status INT;
+    
+    -- Attempt to acquire the lock
+    SELECT GET_LOCK(lock_name, timeout_seconds) INTO lock_status;
+    
+    -- Check if the lock was acquired
+    IF lock_status <> 1 THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Failed to acquire lock';
+    END IF;
+END //
+
 CREATE PROCEDURE sp_insert(IN pin VARCHAR(255))
 BEGIN
     INSERT INTO inserts_table (field_varchar) VALUES (pin);

--- a/test/integration/db_setup.sql
+++ b/test/integration/db_setup.sql
@@ -68,6 +68,10 @@ INSERT INTO multifield_table VALUES
     (1, "aaa", 11, 1.1, 0.1),
     (2, "bbb", 22, NULL, 0.2);
 
+CREATE TABLE locks_table(
+    id INT NOT NULL PRIMARY KEY AUTO_INCREMENT
+);
+
 -- Tables to test we retrieve correctly values of every possible type
 -- Every type gets a separate table. Each field within the table is a possible variant of this same type
 -- Every row is a test case, identified by the id column.

--- a/test/integration/include/test_integration/connect_params_builder.hpp
+++ b/test/integration/include/test_integration/connect_params_builder.hpp
@@ -16,6 +16,7 @@
 #include <boost/mysql/string_view.hpp>
 
 #include <cstdint>
+#include <string>
 
 #include "test_common/ci_server.hpp"
 
@@ -31,9 +32,9 @@ class connect_params_builder
 public:
     connect_params_builder() { addr_.emplace_host_and_port(get_hostname()); }
 
-    connect_params_builder& server_address(any_address addr)
+    connect_params_builder& set_tcp(std::string hostname, unsigned short port)
     {
-        addr_ = std::move(addr);
+        addr_.emplace_host_and_port(std::move(hostname), port);
         return *this;
     }
 

--- a/test/integration/include/test_integration/connect_params_builder.hpp
+++ b/test/integration/include/test_integration/connect_params_builder.hpp
@@ -31,6 +31,12 @@ class connect_params_builder
 public:
     connect_params_builder() { addr_.emplace_host_and_port(get_hostname()); }
 
+    connect_params_builder& server_address(any_address addr)
+    {
+        addr_ = std::move(addr);
+        return *this;
+    }
+
     connect_params_builder& set_unix()
     {
         addr_.emplace_unix_path(default_unix_path);

--- a/test/integration/test/any_connection.cpp
+++ b/test/integration/test/any_connection.cpp
@@ -429,9 +429,10 @@ BOOST_FIXTURE_TEST_CASE(op_in_progress_execute, io_context_fixture)
 BOOST_FIXTURE_TEST_CASE(op_in_progress_connect, any_connection_fixture)
 {
     // Launch a connect op
-    auto connect_result = conn.async_connect(connect_params_builder().build(), as_netresult);
+    const auto params = connect_params_builder().build();
+    auto connect_result = conn.async_connect(params, as_netresult);
 
-    // While in progress, launch another one, with different params (regression check).
+    // While in progress, launch another one, with different params.
     // This fails with the expected error
     conn.async_connect(
             connect_params_builder()

--- a/test/integration/test/any_connection.cpp
+++ b/test/integration/test/any_connection.cpp
@@ -429,10 +429,7 @@ BOOST_FIXTURE_TEST_CASE(op_in_progress_connect, any_connection_fixture)
     // While in progress, launch another one, with different params.
     // This fails with the expected error
     conn.async_connect(
-            connect_params_builder()
-                .server_address(host_and_port{"bad", 1000})
-                .credentials("bad_username", "bad_password")
-                .build(),
+            connect_params_builder().set_tcp("bad", 1000).credentials("bad_username", "bad_password").build(),
             as_netresult
     )
         .validate_error(client_errc::operation_in_progress);

--- a/test/integration/test/handshake.cpp
+++ b/test/integration/test/handshake.cpp
@@ -177,9 +177,10 @@ struct caching_sha2_lock : any_connection_fixture
         conn.async_connect(connect_params_builder().credentials("root", "").build(), as_netresult)
             .validate_no_error();
 
-        // Acquire the lock. -1 = no timeout
+        // Acquire the lock, using a long timeout
         results r;
-        conn.async_execute("DO GET_LOCK('sha256_cache', -1)", r, as_netresult).validate_no_error();
+        conn.async_execute("CALL get_lock_checked('sha256_cache', 3600)", r, as_netresult)
+            .validate_no_error();
 
         // The lock is released on fixture destruction, when the connection is closed
     }

--- a/test/integration/test/snippets/overview.cpp
+++ b/test/integration/test/snippets/overview.cpp
@@ -9,7 +9,9 @@
 #ifdef BOOST_ASIO_HAS_CO_AWAIT
 
 #include <boost/mysql/any_connection.hpp>
+#include <boost/mysql/client_errc.hpp>
 #include <boost/mysql/connection_pool.hpp>
+#include <boost/mysql/error_with_diagnostics.hpp>
 #include <boost/mysql/pfr.hpp>
 #include <boost/mysql/pool_params.hpp>
 #include <boost/mysql/results.hpp>
@@ -31,6 +33,7 @@
 #include <string>
 
 #include "test_common/ci_server.hpp"
+#include "test_common/printing.hpp"
 #include "test_integration/any_connection_fixture.hpp"
 #include "test_integration/run_coro.hpp"
 #include "test_integration/snippets/credentials.hpp"
@@ -38,23 +41,6 @@
 namespace mysql = boost::mysql;
 namespace asio = boost::asio;
 using namespace boost::mysql::test;
-
-// Defined outside the namespace to prevent unused warnings
-#if !defined(BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
-asio::awaitable<void> dont_run(mysql::any_connection& conn)
-{
-    //[overview_async_dont
-    // Coroutine body
-    // DO NOT DO THIS!!!!
-    mysql::results result1, result2;
-    co_await asio::experimental::make_parallel_group(
-        conn.async_execute("SELECT 1", result1, asio::deferred),
-        conn.async_execute("SELECT 2", result2, asio::deferred)
-    )
-        .async_wait(asio::experimental::wait_for_all(), asio::deferred);
-    //]
-}
-#endif
 
 inline namespace overview {
 //[overview_static_struct
@@ -169,6 +155,27 @@ asio::awaitable<void> overview_coro(mysql::any_connection& conn)
         );
         //]
     }
+#if !defined(BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
+    {
+        try
+        {
+            //[overview_async_parallel
+            // This is an error: a single connection can't run two operations
+            // in parallel. Create more connections or use connection_pool, instead.
+            mysql::results result1, result2;
+            co_await asio::experimental::make_parallel_group(
+                conn.async_execute("SELECT 1", result1, asio::deferred),
+                conn.async_execute("SELECT 2", result2, asio::deferred)
+            )
+                .async_wait(asio::experimental::wait_for_all(), asio::deferred);
+            //]
+        }
+        catch (const mysql::error_with_diagnostics& err)
+        {
+            BOOST_TEST(err.code() == mysql::client_errc::operation_in_progress);
+        }
+    }
+#endif
     {
         //[overview_no_exceptions
         mysql::error_code ec;

--- a/test/unit/include/test_unit/algo_test.hpp
+++ b/test/unit/include/test_unit/algo_test.hpp
@@ -26,7 +26,6 @@
 #include <cstdint>
 #include <vector>
 
-#include "test_common/create_diagnostics.hpp"
 #include "test_common/source_location.hpp"
 
 namespace boost {
@@ -90,7 +89,6 @@ class BOOST_ATTRIBUTE_NODISCARD algo_test
 
     static void handle_read(detail::connection_state_data& st, const step_t& op);
 
-    // TODO: do we need to pass diagnostics& here?
     detail::next_action run_algo_until_step(
         any_algo_ref algo,
         detail::connection_state_data& st,
@@ -103,7 +101,6 @@ class BOOST_ATTRIBUTE_NODISCARD algo_test
     void check_impl(
         any_algo_ref algo,
         detail::connection_state_data& st,
-        diagnostics& diag,
         error_code expected_ec,
         const diagnostics& expected_diag,
         source_location loc
@@ -114,7 +111,6 @@ class BOOST_ATTRIBUTE_NODISCARD algo_test
     void check_network_errors_impl(
         any_algo_ref algo,
         detail::connection_state_data& st,
-        diagnostics& diag,
         std::size_t step_number,
         source_location loc
     ) const;
@@ -177,7 +173,7 @@ public:
         source_location loc = BOOST_MYSQL_CURRENT_LOCATION
     ) const
     {
-        check_impl(fix.algo, fix.st, fix.diag, expected_ec, expected_diag, loc);
+        check_impl(fix.algo, fix.st, expected_ec, expected_diag, loc);
     }
 
     template <class AlgoFixture>
@@ -186,7 +182,7 @@ public:
         for (std::size_t i = 0; i < num_steps(); ++i)
         {
             AlgoFixture fix;
-            check_network_errors_impl(fix.algo, fix.st, fix.diag, i, loc);
+            check_network_errors_impl(fix.algo, fix.st, i, loc);
         }
     }
 };
@@ -196,18 +192,12 @@ struct algo_fixture_base
     static constexpr std::size_t default_max_buffsize = 1024u;
 
     detail::connection_state_data st;
-    diagnostics diag;
 
-    algo_fixture_base(
-        diagnostics initial_diag = create_server_diag("Diagnostics not cleared"),
-        std::size_t max_buffer_size = default_max_buffsize
-    )
-        : st(max_buffer_size, max_buffer_size), diag(std::move(initial_diag))
+    algo_fixture_base(std::size_t max_buffer_size = default_max_buffsize)
+        : st(max_buffer_size, max_buffer_size)
     {
         st.write_buffer.push_back(0xff);  // Check that we clear the write buffer at each step
     }
-
-    algo_fixture_base(std::size_t max_buffer_size) : algo_fixture_base(diagnostics(), max_buffer_size) {}
 };
 
 }  // namespace test

--- a/test/unit/src/utils.cpp
+++ b/test/unit/src/utils.cpp
@@ -164,6 +164,7 @@ public:
         BOOST_TEST(st_.ssl == expected_ssl);
         BOOST_TEST(st_.backslash_escapes == expected_backslash_escapes);
         BOOST_TEST(st_.current_charset == expected_charset);
+        BOOST_TEST(!st_.op_in_progress);  // No algorithm should modify this
     }
 };
 

--- a/test/unit/src/utils.cpp
+++ b/test/unit/src/utils.cpp
@@ -173,7 +173,6 @@ public:
 void boost::mysql::test::algo_test::check_network_errors_impl(
     any_algo_ref algo,
     detail::connection_state_data& st,
-    diagnostics& diag,
     std::size_t step_number,
     source_location loc
 ) const
@@ -186,6 +185,7 @@ void boost::mysql::test::algo_test::check_network_errors_impl(
         state_checker checker(st, state_changes_);
 
         // Run all the steps that shouldn't cause an error
+        diagnostics diag;  // Clearing diagnostics is not the algo's responsibility
         auto act = run_algo_until_step(algo, st, diag, step_number);
         BOOST_TEST_REQUIRE(act.type() == steps_[step_number].type);
 
@@ -205,7 +205,6 @@ void boost::mysql::test::algo_test::check_network_errors_impl(
 void boost::mysql::test::algo_test::check_impl(
     any_algo_ref algo,
     detail::connection_state_data& st,
-    diagnostics& diag,
     error_code expected_ec,
     const diagnostics& expected_diag,
     source_location loc
@@ -217,6 +216,7 @@ void boost::mysql::test::algo_test::check_impl(
         state_checker checker(st, state_changes_);
 
         // Run the op until completion
+        diagnostics diag;  // Clearing diagnostics is not the algo's responsibility
         auto act = run_algo_until_step(algo, st, diag, steps_.size());
 
         // Check that we've finished

--- a/test/unit/test/client_errc.cpp
+++ b/test/unit/test/client_errc.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(coverage)
 {
     // Check that no value causes problems.
     // Ensure that all branches of the switch/case are covered
-    for (int i = 1; i <= 25; ++i)
+    for (int i = 1; i <= 26; ++i)
     {
         BOOST_TEST_CONTEXT(i)
         {

--- a/test/unit/test/detail/engine_impl.cpp
+++ b/test/unit/test/detail/engine_impl.cpp
@@ -329,24 +329,56 @@ BOOST_AUTO_TEST_CASE(next_action_write)
     }
 }
 
-// returning next_action::connect/ssl_handshake/ssl_shutdown/close calls the relevant stream function
+// returning next_action::connect calls the relevant stream function
+BOOST_AUTO_TEST_CASE(next_action_connect)
+{
+    struct
+    {
+        const char* name;
+        signature_t fn;
+    } test_cases[] = {
+        {"sync",  sync_fn },
+        {"async", async_fn},
+    };
+
+    for (const auto& tc : test_cases)
+    {
+        BOOST_TEST_CONTEXT(tc.name)
+        {
+            // Setup
+            const int server_address = 42;  // The connect arg is just a const void* that is passed around
+            io_context_fixture fix;
+            mock_algo algo(next_action::connect(&server_address));
+            test_engine eng{fix.ctx.get_executor()};
+
+            tc.fn(eng, any_resumable_ref(algo)).validate_no_error_nodiag();
+            BOOST_TEST(eng.value.stream().calls.size() == 1u);
+            BOOST_TEST(eng.value.stream().calls[0].type() == next_action_type::connect);
+            BOOST_TEST(eng.value.stream().calls[0].connect_endpoint() == &server_address);
+            algo.check_calls({
+                {error_code(), 0u},
+                {error_code(), 0u}
+            });
+            // The testing infrastructure checks that we post correctly in async functions
+        }
+    }
+}
+
+// returning next_action::ssl_handshake/ssl_shutdown/close calls the relevant stream function
 BOOST_AUTO_TEST_CASE(next_action_other)
 {
-    // TODO: check connect args
     struct
     {
         const char* name;
         signature_t fn;
         next_action act;
     } test_cases[] = {
-        {"connect_sync",        sync_fn,  next_action::connect(nullptr)},
-        {"connect_async",       async_fn, next_action::connect(nullptr)},
-        {"ssl_handshake_sync",  sync_fn,  next_action::ssl_handshake() },
-        {"ssl_handshake_async", async_fn, next_action::ssl_handshake() },
-        {"ssl_shutdown_sync",   sync_fn,  next_action::ssl_shutdown()  },
-        {"ssl_shutdown_async",  async_fn, next_action::ssl_shutdown()  },
-        {"close_sync",          sync_fn,  next_action::close()         },
-        {"close_async",         async_fn, next_action::close()         },
+        {"ssl_handshake_sync",  sync_fn,  next_action::ssl_handshake()},
+        {"ssl_handshake_async", async_fn, next_action::ssl_handshake()},
+        {"ssl_shutdown_sync",   sync_fn,  next_action::ssl_shutdown() },
+        {"ssl_shutdown_async",  async_fn, next_action::ssl_shutdown() },
+        {"close_sync",          sync_fn,  next_action::close()        },
+        {"close_async",         async_fn, next_action::close()        },
     };
 
     for (const auto& tc : test_cases)
@@ -371,11 +403,11 @@ BOOST_AUTO_TEST_CASE(next_action_other)
 }
 
 // Stream errors get propagated to the algorithm and don't exit the loop
-// TODO: check connect args
 BOOST_AUTO_TEST_CASE(stream_errors)
 {
     std::array<std::uint8_t, 8> buff{};
     const std::array<std::uint8_t, 4> cbuff{};
+    constexpr int server_address = 42;
 
     struct
     {
@@ -383,18 +415,18 @@ BOOST_AUTO_TEST_CASE(stream_errors)
         signature_t fn;
         next_action act;
     } test_cases[] = {
-        {"read_sync",           sync_fn,  next_action::read({buff, false})  },
-        {"read_async",          async_fn, next_action::read({buff, false})  },
-        {"write_sync",          sync_fn,  next_action::write({cbuff, false})},
-        {"write_async",         async_fn, next_action::write({cbuff, false})},
-        {"connect_sync",        sync_fn,  next_action::connect(nullptr)     },
-        {"connect_async",       async_fn, next_action::connect(nullptr)     },
-        {"ssl_handshake_sync",  sync_fn,  next_action::ssl_handshake()      },
-        {"ssl_handshake_async", async_fn, next_action::ssl_handshake()      },
-        {"ssl_shutdown_sync",   sync_fn,  next_action::ssl_shutdown()       },
-        {"ssl_shutdown_async",  async_fn, next_action::ssl_shutdown()       },
-        {"close_sync",          sync_fn,  next_action::close()              },
-        {"close_async",         async_fn, next_action::close()              },
+        {"read_sync",           sync_fn,  next_action::read({buff, false})     },
+        {"read_async",          async_fn, next_action::read({buff, false})     },
+        {"write_sync",          sync_fn,  next_action::write({cbuff, false})   },
+        {"write_async",         async_fn, next_action::write({cbuff, false})   },
+        {"connect_sync",        sync_fn,  next_action::connect(&server_address)},
+        {"connect_async",       async_fn, next_action::connect(&server_address)},
+        {"ssl_handshake_sync",  sync_fn,  next_action::ssl_handshake()         },
+        {"ssl_handshake_async", async_fn, next_action::ssl_handshake()         },
+        {"ssl_shutdown_sync",   sync_fn,  next_action::ssl_shutdown()          },
+        {"ssl_shutdown_async",  async_fn, next_action::ssl_shutdown()          },
+        {"close_sync",          sync_fn,  next_action::close()                 },
+        {"close_async",         async_fn, next_action::close()                 },
     };
 
     for (const auto& tc : test_cases)
@@ -512,13 +544,13 @@ BOOST_AUTO_TEST_CASE(resume_error_successive_calls)
         {
             // Setup
             io_context_fixture fix;
-            mock_algo algo(next_action::connect(nullptr), next_action(tc.ec));
+            mock_algo algo(next_action::ssl_handshake(), next_action(tc.ec));
             test_engine eng{fix.ctx.get_executor()};
 
             tc.fn(eng, any_resumable_ref(algo))
                 .validate_error(tc.ec, create_server_diag("<diagnostics unavailable>"));
             BOOST_TEST(eng.value.stream().calls.size() == 1u);
-            BOOST_TEST(eng.value.stream().calls[0].type() == next_action_type::connect);
+            BOOST_TEST(eng.value.stream().calls[0].type() == next_action_type::ssl_handshake);
             algo.check_calls({
                 {error_code(), 0u},
                 {error_code(), 0u}

--- a/test/unit/test/is_fatal_error.cpp
+++ b/test/unit/test/is_fatal_error.cpp
@@ -83,6 +83,7 @@ BOOST_AUTO_TEST_CASE(test_is_fatal_error)
         {"format_string_invalid_specifier", client_errc::format_string_invalid_specifier,                   false},
         {"format_arg_not_found",            client_errc::format_arg_not_found,                              false},
         {"unknown_character_set",           client_errc::unknown_character_set,                             false},
+        {"operation_in_progress",           client_errc::operation_in_progress,                             false},
 
         // Fatal server errors
         {"ER_UNKNOWN_COM_ERROR",            common_server_errc::er_unknown_com_error,                       true },

--- a/test/unit/test/sansio/close_statement.cpp
+++ b/test/unit/test/sansio/close_statement.cpp
@@ -39,7 +39,7 @@ static std::vector<std::uint8_t> expected_request()
 
 struct fixture : algo_fixture_base
 {
-    detail::run_pipeline_algo algo{diag, detail::setup_close_statement_pipeline(st, {3})};
+    detail::run_pipeline_algo algo{detail::setup_close_statement_pipeline(st, {3})};
 };
 
 BOOST_AUTO_TEST_CASE(success)

--- a/test/unit/test/sansio/close_statement.cpp
+++ b/test/unit/test/sansio/close_statement.cpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 
 #include "test_common/buffer_concat.hpp"
+#include "test_common/create_diagnostics.hpp"
 #include "test_unit/algo_test.hpp"
 #include "test_unit/create_err.hpp"
 #include "test_unit/create_frame.hpp"

--- a/test/unit/test/sansio/execute.cpp
+++ b/test/unit/test/sansio/execute.cpp
@@ -42,7 +42,7 @@ static constexpr std::uint8_t serialized_select_1[] = {0x03, 0x53, 0x45, 0x4c, 0
 struct read_response_fixture : algo_fixture_base
 {
     mock_execution_processor proc;
-    detail::read_execute_response_algo algo{diag, &proc};
+    detail::read_execute_response_algo algo{&proc};
 
     read_response_fixture() { proc.sequence_number() = 42; }
 };
@@ -179,7 +179,7 @@ struct execute_fixture : algo_fixture_base
     mock_execution_processor proc;
     detail::execute_algo algo;
 
-    execute_fixture(any_execution_request req = {"SELECT 1"}) : algo(diag, {req, &proc}) {}
+    execute_fixture(any_execution_request req = {"SELECT 1"}) : algo({req, &proc}) {}
 };
 
 BOOST_AUTO_TEST_CASE(execute_success_eof)

--- a/test/unit/test/sansio/ping.cpp
+++ b/test/unit/test/sansio/ping.cpp
@@ -15,6 +15,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "test_common/create_diagnostics.hpp"
 #include "test_common/printing.hpp"
 #include "test_unit/algo_test.hpp"
 #include "test_unit/create_err.hpp"
@@ -32,9 +33,6 @@ BOOST_AUTO_TEST_SUITE(test_ping)
 struct read_response_fixture : algo_fixture_base
 {
     detail::read_ping_response_algo algo{57};
-
-    // Clearing diagnostics is not this algorithm's responsibility
-    read_response_fixture() : algo_fixture_base(diagnostics()) {}
 };
 
 BOOST_AUTO_TEST_CASE(read_response_success)

--- a/test/unit/test/sansio/ping.cpp
+++ b/test/unit/test/sansio/ping.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_SUITE(test_ping)
 //
 struct read_response_fixture : algo_fixture_base
 {
-    detail::read_ping_response_algo algo{diag, 57};
+    detail::read_ping_response_algo algo{57};
 
     // Clearing diagnostics is not this algorithm's responsibility
     read_response_fixture() : algo_fixture_base(diagnostics()) {}
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(read_response_error_packet)
 
 struct ping_fixture : algo_fixture_base
 {
-    detail::run_pipeline_algo algo{diag, detail::setup_ping_pipeline(st)};
+    detail::run_pipeline_algo algo{detail::setup_ping_pipeline(st)};
 };
 
 BOOST_AUTO_TEST_CASE(ping_success)

--- a/test/unit/test/sansio/prepare_statement.cpp
+++ b/test/unit/test/sansio/prepare_statement.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "test_common/create_diagnostics.hpp"
 #include "test_unit/algo_test.hpp"
 #include "test_unit/create_coldef_frame.hpp"
 #include "test_unit/create_err.hpp"
@@ -31,9 +32,6 @@ BOOST_AUTO_TEST_SUITE(test_prepare_statement)
 struct read_response_fixture : algo_fixture_base
 {
     detail::read_prepare_statement_response_algo algo{19};
-
-    // Clearing diagnostics is not this algorithm's responsibility
-    read_response_fixture() : algo_fixture_base(diagnostics()) {}
 
     statement result() const { return algo.result(st); }
 };

--- a/test/unit/test/sansio/prepare_statement.cpp
+++ b/test/unit/test/sansio/prepare_statement.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_SUITE(test_prepare_statement)
 //
 struct read_response_fixture : algo_fixture_base
 {
-    detail::read_prepare_statement_response_algo algo{diag, 19};
+    detail::read_prepare_statement_response_algo algo{19};
 
     // Clearing diagnostics is not this algorithm's responsibility
     read_response_fixture() : algo_fixture_base(diagnostics()) {}
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(read_response_error_packet)
 //
 struct prepare_fixture : algo_fixture_base
 {
-    detail::prepare_statement_algo algo{diag, {"SELECT 1"}};
+    detail::prepare_statement_algo algo{{"SELECT 1"}};
 
     prepare_fixture() = default;
     prepare_fixture(std::size_t max_bufsize) : algo_fixture_base(max_bufsize) {}

--- a/test/unit/test/sansio/read_resultset_head.cpp
+++ b/test/unit/test/sansio/read_resultset_head.cpp
@@ -19,6 +19,7 @@
 
 #include "test_common/buffer_concat.hpp"
 #include "test_common/check_meta.hpp"
+#include "test_common/create_diagnostics.hpp"
 #include "test_unit/algo_test.hpp"
 #include "test_unit/create_coldef_frame.hpp"
 #include "test_unit/create_err.hpp"

--- a/test/unit/test/sansio/read_resultset_head.cpp
+++ b/test/unit/test/sansio/read_resultset_head.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_SUITE(test_read_resultset_head)
 struct fixture : algo_fixture_base
 {
     mock_execution_processor proc;
-    detail::read_resultset_head_algo algo{diag, {&proc}};
+    detail::read_resultset_head_algo algo{{&proc}};
 
     fixture()
     {

--- a/test/unit/test/sansio/read_some_rows.cpp
+++ b/test/unit/test/sansio/read_some_rows.cpp
@@ -253,7 +253,6 @@ BOOST_AUTO_TEST_CASE(successive_calls_keep_parsing_state)
 
     // Run the algo again
     fix.algo.reset();
-    fix.diag = create_server_diag("Diagnostics not cleared");
     algo_test()
         .expect_read(buffer_builder().add(boost::span<const std::uint8_t>(eof).subspan(6)).build())
         .check(fix);

--- a/test/unit/test/sansio/read_some_rows.cpp
+++ b/test/unit/test/sansio/read_some_rows.cpp
@@ -42,7 +42,6 @@ struct fixture : algo_fixture_base
     mock_execution_processor proc;
     std::array<row1, 3> storage;
     detail::read_some_rows_algo algo{
-        diag,
         {&proc, ref()}
     };
 

--- a/test/unit/test/sansio/read_some_rows_dynamic.cpp
+++ b/test/unit/test/sansio/read_some_rows_dynamic.cpp
@@ -19,7 +19,6 @@
 #include "test_common/buffer_concat.hpp"
 #include "test_unit/algo_test.hpp"
 #include "test_unit/create_execution_processor.hpp"
-#include "test_unit/create_frame.hpp"
 #include "test_unit/create_meta.hpp"
 #include "test_unit/create_ok.hpp"
 #include "test_unit/create_ok_frame.hpp"
@@ -34,7 +33,7 @@ BOOST_AUTO_TEST_SUITE(test_read_some_rows_dynamic)
 struct fixture : algo_fixture_base
 {
     execution_state_impl exec_st;
-    detail::read_some_rows_dynamic_algo algo{diag, {&exec_st}};
+    detail::read_some_rows_dynamic_algo algo{{&exec_st}};
 
     fixture()
     {

--- a/test/unit/test/sansio/reset_connection.cpp
+++ b/test/unit/test/sansio/reset_connection.cpp
@@ -35,9 +35,6 @@ BOOST_AUTO_TEST_SUITE(test_reset_connection)
 struct read_response_fixture : algo_fixture_base
 {
     detail::read_reset_connection_response_algo algo{11};
-
-    // Clearing diagnostics is not this algorithm's responsibility
-    read_response_fixture() : algo_fixture_base(diagnostics()) {}
 };
 
 BOOST_AUTO_TEST_CASE(read_response_success)

--- a/test/unit/test/sansio/reset_connection.cpp
+++ b/test/unit/test/sansio/reset_connection.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_SUITE(test_reset_connection)
 //
 struct read_response_fixture : algo_fixture_base
 {
-    detail::read_reset_connection_response_algo algo{diag, 11};
+    detail::read_reset_connection_response_algo algo{11};
 
     // Clearing diagnostics is not this algorithm's responsibility
     read_response_fixture() : algo_fixture_base(diagnostics()) {}
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(read_response_error_packet)
 //
 struct reset_conn_fixture : algo_fixture_base
 {
-    detail::run_pipeline_algo algo{diag, detail::setup_reset_connection_pipeline(st)};
+    detail::run_pipeline_algo algo{detail::setup_reset_connection_pipeline(st)};
 };
 
 BOOST_AUTO_TEST_CASE(success)

--- a/test/unit/test/sansio/run_pipeline.cpp
+++ b/test/unit/test/sansio/run_pipeline.cpp
@@ -68,7 +68,7 @@ struct fixture_base : algo_fixture_base
         span<const std::uint8_t> req_buffer = mock_request,
         std::vector<stage_response>* response = nullptr
     )
-        : algo(diag, {req_buffer, stages, response})
+        : algo({req_buffer, stages, response})
     {
     }
 };

--- a/test/unit/test/sansio/set_character_set.cpp
+++ b/test/unit/test/sansio/set_character_set.cpp
@@ -76,7 +76,7 @@ struct read_response_fixture : algo_fixture_base
 
     // Clearing diagnostics is not this algorithm's responsibility
     read_response_fixture(character_set charset = utf8mb4_charset)
-        : algo_fixture_base(diagnostics()), algo(diag, charset, 29)
+        : algo_fixture_base(diagnostics()), algo(charset, 29)
     {
     }
 };
@@ -136,11 +136,8 @@ struct set_charset_fixture : algo_fixture_base
 {
     detail::set_character_set_algo algo;
 
-    set_charset_fixture(character_set charset = utf8mb4_charset) : algo(diag, {charset}) {}
-    set_charset_fixture(std::size_t max_bufsize)
-        : algo_fixture_base(max_bufsize), algo(diag, {utf8mb4_charset})
-    {
-    }
+    set_charset_fixture(character_set charset = utf8mb4_charset) : algo({charset}) {}
+    set_charset_fixture(std::size_t max_bufsize) : algo_fixture_base(max_bufsize), algo({utf8mb4_charset}) {}
 };
 
 BOOST_AUTO_TEST_CASE(set_charset_success)

--- a/test/unit/test/sansio/set_character_set.cpp
+++ b/test/unit/test/sansio/set_character_set.cpp
@@ -74,11 +74,7 @@ struct read_response_fixture : algo_fixture_base
 {
     detail::read_set_character_set_response_algo algo;
 
-    // Clearing diagnostics is not this algorithm's responsibility
-    read_response_fixture(character_set charset = utf8mb4_charset)
-        : algo_fixture_base(diagnostics()), algo(charset, 29)
-    {
-    }
+    read_response_fixture(character_set charset = utf8mb4_charset) : algo(charset, 29) {}
 };
 
 BOOST_AUTO_TEST_CASE(read_response_success)

--- a/test/unit/test/sansio/start_execution.cpp
+++ b/test/unit/test/sansio/start_execution.cpp
@@ -51,7 +51,7 @@ struct fixture : algo_fixture_base
         any_execution_request req = any_execution_request("SELECT 1"),
         std::size_t max_bufsize = default_max_buffsize
     )
-        : algo_fixture_base(max_bufsize), algo(diag, {req, &proc})
+        : algo_fixture_base(max_bufsize), algo({req, &proc})
     {
     }
 };

--- a/test/unit/test/sansio/top_level_algo.cpp
+++ b/test/unit/test/sansio/top_level_algo.cpp
@@ -52,11 +52,6 @@ void transfer(span<std::uint8_t> buff, span<const std::uint8_t> bytes)
     std::memcpy(buff.data(), bytes.data(), bytes.size());
 }
 
-void transfer(span<std::uint8_t> buff, const std::vector<std::uint8_t>& bytes)
-{
-    transfer(buff, boost::span<const std::uint8_t>(bytes));
-}
-
 const u8vec msg1{0x01, 0x02, 0x03};
 const u8vec msg2(50, 0x04);
 
@@ -130,7 +125,7 @@ BOOST_AUTO_TEST_CASE(read_short_and_buffer_resizing)
     diagnostics diag;
     top_level_algo<mock_algo> algo(st, diag);
 
-    // Initial run yields a read request and resizes the buffer aprorpiately
+    // Initial run yields a read request and resizes the buffer appropriately
     auto act = algo.resume(error_code(), 0);
     BOOST_TEST(act.type() == next_action_type::read);
     BOOST_TEST(act.read_args().buffer.data() == st.reader.buffer().data());

--- a/test/unit/test/sansio/top_level_algo.cpp
+++ b/test/unit/test/sansio/top_level_algo.cpp
@@ -38,7 +38,7 @@ using boost::mysql::client_errc;
 using boost::mysql::error_code;
 using u8vec = std::vector<std::uint8_t>;
 
-BOOST_AUTO_TEST_SUITE(test_algo_runner)
+BOOST_AUTO_TEST_SUITE(test_top_level_algo)
 
 void transfer(span<std::uint8_t> buff, span<const std::uint8_t> bytes)
 {

--- a/test/unit/test/sansio/top_level_algo.cpp
+++ b/test/unit/test/sansio/top_level_algo.cpp
@@ -38,7 +38,6 @@ using boost::asio::coroutine;
 using boost::mysql::client_errc;
 using boost::mysql::diagnostics;
 using boost::mysql::error_code;
-using u8vec = std::vector<std::uint8_t>;
 
 // TODO: test that diagnostics are cleared
 // TODO: test that the diagnostics used to construct the object are passed
@@ -52,8 +51,8 @@ void transfer(span<std::uint8_t> buff, span<const std::uint8_t> bytes)
     std::memcpy(buff.data(), bytes.data(), bytes.size());
 }
 
-const u8vec msg1{0x01, 0x02, 0x03};
-const u8vec msg2(50, 0x04);
+const std::vector<std::uint8_t> msg1{0x01, 0x02, 0x03};
+const std::vector<std::uint8_t> msg2(50, 0x04);
 
 BOOST_AUTO_TEST_CASE(read_cached)
 {

--- a/test/unit/test/sansio/top_level_algo.cpp
+++ b/test/unit/test/sansio/top_level_algo.cpp
@@ -479,7 +479,6 @@ BOOST_AUTO_TEST_CASE(ssl_shutdown)
 
 BOOST_AUTO_TEST_CASE(connect)
 {
-    // TODO: check the connect arg
     struct mock_algo
     {
         boost::asio::coroutine coro;
@@ -489,7 +488,7 @@ BOOST_AUTO_TEST_CASE(connect)
             BOOST_ASIO_CORO_REENTER(coro)
             {
                 BOOST_TEST(ec == error_code());
-                BOOST_ASIO_CORO_YIELD return next_action::connect(nullptr);
+                BOOST_ASIO_CORO_YIELD return next_action::connect(reinterpret_cast<const void*>(42u));
                 BOOST_TEST(ec == client_errc::wrong_num_params);
             }
             return next_action();
@@ -500,9 +499,11 @@ BOOST_AUTO_TEST_CASE(connect)
     diagnostics diag;
     top_level_algo<mock_algo> algo(st, diag);
 
-    // Initial run yields a connect request. These are always returned
+    // Initial run yields a connect request. These are always returned.
+    // The connect argument is not used, only forwarded
     auto act = algo.resume(error_code(), 0);
     BOOST_TEST(act.type() == next_action_type::connect);
+    BOOST_TEST(act.connect_endpoint() == reinterpret_cast<const void*>(42u));
 
     // Fail the op
     act = algo.resume(client_errc::wrong_num_params, 0);


### PR DESCRIPTION
connection and any_connection now check whether there is an in-progress async operation, and fail with client_errc::operation_in_progress if there is one. This situation no longer triggers undefined behavior.
Refactored the internal sans-io algorithms

close #405 