### PR TITLE
Added quit_connection unit tests and refactored

### DIFF
--- a/include/boost/mysql/impl/connection_impl.ipp
+++ b/include/boost/mysql/impl/connection_impl.ipp
@@ -70,7 +70,7 @@ boost::mysql::metadata_mode boost::mysql::detail::connection_impl::meta_mode() c
 
 void boost::mysql::detail::connection_impl::set_meta_mode(metadata_mode v) { st_->data().meta_mode = v; }
 
-bool boost::mysql::detail::connection_impl::ssl_active() const { return st_->data().ssl_active(); }
+bool boost::mysql::detail::connection_impl::ssl_active() const { return st_->data().tls_active; }
 
 bool boost::mysql::detail::connection_impl::backslash_escapes() const
 {

--- a/include/boost/mysql/impl/internal/sansio/connection_state_data.hpp
+++ b/include/boost/mysql/impl/internal/sansio/connection_state_data.hpp
@@ -35,7 +35,6 @@ enum class ssl_state
     unsupported,
     inactive,
     active,
-    torn_down,
 };
 
 struct connection_state_data

--- a/include/boost/mysql/impl/internal/sansio/handshake.hpp
+++ b/include/boost/mysql/impl/internal/sansio/handshake.hpp
@@ -105,7 +105,7 @@ class handshake_algo
 
         // Check capabilities
         capabilities negotiated_caps;
-        err = process_capabilities(hparams_, hello, negotiated_caps, st.supports_ssl());
+        err = process_capabilities(hparams_, hello, negotiated_caps, st.tls_supported);
         if (err)
             return err;
 
@@ -234,7 +234,7 @@ public:
                 BOOST_MYSQL_YIELD(resume_point_, 3, next_action::ssl_handshake())
 
                 // Mark the connection as using ssl
-                st.ssl = ssl_state::active;
+                st.tls_active = true;
             }
 
             // Compose and send handshake response

--- a/include/boost/mysql/impl/internal/sansio/quit_connection.hpp
+++ b/include/boost/mysql/impl/internal/sansio/quit_connection.hpp
@@ -37,10 +37,9 @@ public:
         {
         case 0:
             // Mark the session as finished
-            should_perform_shutdown_ = st.ssl_active();
+            should_perform_shutdown_ = st.tls_active;
             st.is_connected = false;
-            if (st.ssl_active())
-                st.ssl = ssl_state::inactive;
+            st.tls_active = false;
 
             // Send quit message
             BOOST_MYSQL_YIELD(resume_point_, 1, st.write(quit_command(), sequence_number_))

--- a/include/boost/mysql/impl/internal/sansio/quit_connection.hpp
+++ b/include/boost/mysql/impl/internal/sansio/quit_connection.hpp
@@ -46,7 +46,8 @@ public:
             if (ec)
                 return ec;
 
-            // Shutdown SSL. MySQL doesn't always shut down SSL correctly, so we ignore this error.
+            // Attempt TLS shutdown. MySQL usually just closes the socket, instead of
+            // sending the close_notify message required by the shutdown, so we ignore this error.
             if (st.ssl == ssl_state::active)
             {
                 BOOST_MYSQL_YIELD(resume_point_, 2, next_action::ssl_shutdown())

--- a/include/boost/mysql/impl/internal/sansio/quit_connection.hpp
+++ b/include/boost/mysql/impl/internal/sansio/quit_connection.hpp
@@ -50,7 +50,7 @@ public:
             if (st.ssl == ssl_state::active)
             {
                 BOOST_MYSQL_YIELD(resume_point_, 2, next_action::ssl_shutdown())
-                st.ssl = ssl_state::torn_down;
+                st.ssl = ssl_state::inactive;
             }
 
             // Done

--- a/include/boost/mysql/impl/internal/sansio/top_level_algo.hpp
+++ b/include/boost/mysql/impl/internal/sansio/top_level_algo.hpp
@@ -103,7 +103,7 @@ public:
                         BOOST_MYSQL_YIELD(
                             resume_point_,
                             1,
-                            next_action::read({st_->reader.buffer(), st_->ssl_active()})
+                            next_action::read({st_->reader.buffer(), st_->tls_active})
                         )
                         valgrind_make_mem_defined(st_->reader.buffer().data(), bytes_transferred);
                         st_->reader.resume(bytes_transferred);
@@ -125,7 +125,7 @@ public:
                         BOOST_MYSQL_YIELD(
                             resume_point_,
                             2,
-                            next_action::write({bytes_to_write_, st_->ssl_active()})
+                            next_action::write({bytes_to_write_, st_->tls_active})
                         )
                         bytes_to_write_ = bytes_to_write_.subspan(bytes_transferred);
                     }

--- a/test/integration/test/snippets/prepared_statements.cpp
+++ b/test/integration/test/snippets/prepared_statements.cpp
@@ -64,7 +64,7 @@ asio::awaitable<void> execute_statement(
 }
 //]
 
-asio::awaitable<void> section_main(asio::io_context& ctx, mysql::any_connection& conn)
+asio::awaitable<void> section_main(mysql::any_connection& conn)
 {
     {
         //[prepared_statements_prepare
@@ -124,7 +124,7 @@ asio::awaitable<void> section_main(asio::io_context& ctx, mysql::any_connection&
 
 BOOST_FIXTURE_TEST_CASE(section_prepared_statements, snippets_fixture)
 {
-    run_coro(ctx, [this]() { return section_main(ctx, conn); });
+    run_coro(ctx, [this]() { return section_main(conn); });
 }
 
 }  // namespace

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
     test/sansio/reset_connection.cpp
     test/sansio/prepare_statement.cpp
     test/sansio/run_pipeline.cpp
+    test/sansio/quit_connection.cpp
 
     test/execution_processor/execution_processor.cpp
     test/execution_processor/execution_state_impl.cpp

--- a/test/unit/Jamfile
+++ b/test/unit/Jamfile
@@ -51,6 +51,7 @@ run
         test/sansio/reset_connection.cpp
         test/sansio/prepare_statement.cpp
         test/sansio/run_pipeline.cpp
+        test/sansio/quit_connection.cpp
 
         test/execution_processor/execution_processor.cpp
         test/execution_processor/execution_state_impl.cpp

--- a/test/unit/include/test_unit/algo_test.hpp
+++ b/test/unit/include/test_unit/algo_test.hpp
@@ -153,6 +153,20 @@ public:
     }
 
     BOOST_ATTRIBUTE_NODISCARD
+    algo_test& will_set_is_connected(bool expected)
+    {
+        state_changes_.is_connected = expected;
+        return *this;
+    }
+
+    BOOST_ATTRIBUTE_NODISCARD
+    algo_test& will_set_ssl(detail::ssl_state expected)
+    {
+        state_changes_.ssl = expected;
+        return *this;
+    }
+
+    BOOST_ATTRIBUTE_NODISCARD
     algo_test& will_set_current_charset(character_set expected)
     {
         state_changes_.current_charset = expected;

--- a/test/unit/include/test_unit/algo_test.hpp
+++ b/test/unit/include/test_unit/algo_test.hpp
@@ -81,7 +81,8 @@ class BOOST_ATTRIBUTE_NODISCARD algo_test
         boost::optional<detail::db_flavor> flavor;
         boost::optional<detail::capabilities> current_capabilities;
         boost::optional<std::uint32_t> connection_id;
-        boost::optional<detail::ssl_state> ssl;
+        boost::optional<bool> tls_supported;
+        boost::optional<bool> tls_active;
         boost::optional<bool> backslash_escapes;
         boost::optional<character_set> current_charset;
     } state_changes_;
@@ -160,9 +161,9 @@ public:
     }
 
     BOOST_ATTRIBUTE_NODISCARD
-    algo_test& will_set_ssl(detail::ssl_state expected)
+    algo_test& will_set_tls_active(bool expected)
     {
-        state_changes_.ssl = expected;
+        state_changes_.tls_active = expected;
         return *this;
     }
 

--- a/test/unit/include/test_unit/printing.hpp
+++ b/test/unit/include/test_unit/printing.hpp
@@ -27,10 +27,6 @@ std::ostream& operator<<(std::ostream& os, const capabilities& caps);
 enum class db_flavor;
 std::ostream& operator<<(std::ostream& os, db_flavor value);
 
-// ssl_state
-enum class ssl_state;
-std::ostream& operator<<(std::ostream& os, ssl_state value);
-
 // resultset_encoding
 enum class resultset_encoding;
 std::ostream& operator<<(std::ostream& os, resultset_encoding t);

--- a/test/unit/src/utils.cpp
+++ b/test/unit/src/utils.cpp
@@ -143,7 +143,8 @@ class boost::mysql::test::algo_test::state_checker
     detail::db_flavor expected_flavor;
     detail::capabilities expected_capabilities;
     std::uint32_t expected_connection_id;
-    detail::ssl_state expected_ssl;
+    bool expected_tls_supported;
+    bool expected_tls_active;
     bool expected_backslash_escapes;
     character_set expected_charset;
 
@@ -154,7 +155,8 @@ public:
           expected_flavor(changes.flavor.value_or(st.flavor)),
           expected_capabilities(changes.current_capabilities.value_or(st.current_capabilities)),
           expected_connection_id(changes.connection_id.value_or(st.connection_id)),
-          expected_ssl(changes.ssl.value_or(st.ssl)),
+          expected_tls_supported(changes.tls_active.value_or(st.tls_supported)),
+          expected_tls_active(changes.tls_active.value_or(st.tls_active)),
           expected_backslash_escapes(changes.backslash_escapes.value_or(st.backslash_escapes)),
           expected_charset(changes.current_charset.value_or(st.current_charset))
     {
@@ -166,7 +168,8 @@ public:
         BOOST_TEST(st_.flavor == expected_flavor);
         BOOST_TEST(st_.current_capabilities == expected_capabilities);
         BOOST_TEST(st_.connection_id == expected_connection_id);
-        BOOST_TEST(st_.ssl == expected_ssl);
+        BOOST_TEST(st_.tls_supported == expected_tls_supported);
+        BOOST_TEST(st_.tls_active == expected_tls_active);
         BOOST_TEST(st_.backslash_escapes == expected_backslash_escapes);
         BOOST_TEST(st_.current_charset == expected_charset);
         BOOST_TEST(!st_.op_in_progress);  // No algorithm should modify this
@@ -620,20 +623,6 @@ static const char* to_string(detail::db_flavor v)
 }
 
 std::ostream& boost::mysql::detail::operator<<(std::ostream& os, db_flavor v) { return os << ::to_string(v); }
-
-// ssl_state
-static const char* to_string(detail::ssl_state v)
-{
-    switch (v)
-    {
-    case detail::ssl_state::unsupported: return "ssl_state::unsupported";
-    case detail::ssl_state::inactive: return "ssl_state::inactive";
-    case detail::ssl_state::active: return "ssl_state::active";
-    default: return "<unknown ssl_state>";
-    }
-}
-
-std::ostream& boost::mysql::detail::operator<<(std::ostream& os, ssl_state v) { return os << ::to_string(v); }
 
 // resultset_encoding
 static const char* to_string(detail::resultset_encoding v)

--- a/test/unit/src/utils.cpp
+++ b/test/unit/src/utils.cpp
@@ -629,7 +629,6 @@ static const char* to_string(detail::ssl_state v)
     case detail::ssl_state::unsupported: return "ssl_state::unsupported";
     case detail::ssl_state::inactive: return "ssl_state::inactive";
     case detail::ssl_state::active: return "ssl_state::active";
-    case detail::ssl_state::torn_down: return "ssl_state::torn_down";
     default: return "<unknown ssl_state>";
     }
 }

--- a/test/unit/test/sansio/quit_connection.cpp
+++ b/test/unit/test/sansio/quit_connection.cpp
@@ -59,14 +59,14 @@ BOOST_AUTO_TEST_CASE(ssl_success)
 {
     // Setup
     fixture fix;
-    fix.st.ssl = detail::ssl_state::active;
+    fix.st.tls_active = true;
 
     // Run the algo
     algo_test()
         .expect_write(expected_request())
         .expect_ssl_shutdown()
         .will_set_is_connected(false)
-        .will_set_ssl(detail::ssl_state::inactive)
+        .will_set_tls_active(false)
         .check(fix);
 }
 
@@ -74,13 +74,13 @@ BOOST_AUTO_TEST_CASE(ssl_error_quit)
 {
     // Setup
     fixture fix;
-    fix.st.ssl = detail::ssl_state::active;
+    fix.st.tls_active = true;
 
     // Run the algo
     algo_test()
         .expect_write(expected_request(), asio::error::network_reset)
         .will_set_is_connected(false)
-        .will_set_ssl(detail::ssl_state::inactive)
+        .will_set_tls_active(false)
         .check(fix, asio::error::network_reset);
 }
 
@@ -88,14 +88,14 @@ BOOST_AUTO_TEST_CASE(ssl_error_shutdown)
 {
     // Setup
     fixture fix;
-    fix.st.ssl = detail::ssl_state::active;
+    fix.st.tls_active = true;
 
     // Run the algo
     algo_test()
         .expect_write(expected_request())
         .expect_ssl_shutdown(asio::error::network_reset)
         .will_set_is_connected(false)
-        .will_set_ssl(detail::ssl_state::inactive)
+        .will_set_tls_active(false)
         .check(fix);  // SSL shutdown errors ignored
 }
 

--- a/test/unit/test/sansio/quit_connection.cpp
+++ b/test/unit/test/sansio/quit_connection.cpp
@@ -1,0 +1,115 @@
+//
+// Copyright (c) 2019-2025 Ruben Perez Hidalgo (rubenperez038 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/impl/internal/sansio/connection_state_data.hpp>
+#include <boost/mysql/impl/internal/sansio/quit_connection.hpp>
+
+#include <boost/asio/error.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+#include "test_unit/algo_test.hpp"
+#include "test_unit/create_frame.hpp"
+
+namespace asio = boost::asio;
+using namespace boost::mysql::test;
+using namespace boost::mysql;
+
+namespace {
+
+BOOST_AUTO_TEST_SUITE(test_quit_connection)
+
+struct fixture : algo_fixture_base
+{
+    detail::quit_connection_algo algo{{}};
+
+    fixture() { st.is_connected = true; }
+};
+
+// A serialized quit request
+std::vector<std::uint8_t> expected_request() { return create_frame(0, {0x01}); }
+
+BOOST_AUTO_TEST_CASE(plaintext_success)
+{
+    // Setup
+    fixture fix;
+
+    // Run the algo
+    algo_test().expect_write(expected_request()).will_set_is_connected(false).check(fix);
+}
+
+BOOST_AUTO_TEST_CASE(plaintext_error_network)
+{
+    // Setup
+    fixture fix;
+
+    // Run the algo
+    algo_test()
+        .expect_write(expected_request(), asio::error::network_reset)
+        .will_set_is_connected(false)  // State change happens even if the quit request fails
+        .check(fix, asio::error::network_reset);
+}
+
+BOOST_AUTO_TEST_CASE(ssl_success)
+{
+    // Setup
+    fixture fix;
+    fix.st.ssl = detail::ssl_state::active;
+
+    // Run the algo
+    algo_test()
+        .expect_write(expected_request())
+        .expect_ssl_shutdown()
+        .will_set_is_connected(false)
+        .will_set_ssl(detail::ssl_state::torn_down)
+        .check(fix);
+}
+
+BOOST_AUTO_TEST_CASE(ssl_error_quit)
+{
+    // Setup
+    fixture fix;
+    fix.st.ssl = detail::ssl_state::active;
+
+    // Run the algo
+    algo_test()
+        .expect_write(expected_request(), asio::error::network_reset)
+        .will_set_is_connected(false)
+        // .will_set_ssl(detail::ssl_state::torn_down)
+        .check(fix, asio::error::network_reset);
+}
+
+BOOST_AUTO_TEST_CASE(ssl_error_shutdown)
+{
+    // Setup
+    fixture fix;
+    fix.st.ssl = detail::ssl_state::active;
+
+    // Run the algo
+    algo_test()
+        .expect_write(expected_request())
+        .expect_ssl_shutdown(asio::error::network_reset)
+        .will_set_is_connected(false)
+        .will_set_ssl(detail::ssl_state::torn_down)
+        .check(fix);  // SSL shutdown errors ignored
+}
+
+// quit runs regardless of the session state we have
+BOOST_AUTO_TEST_CASE(connected_flag_ignored)
+{
+    // Setup
+    fixture fix;
+    fix.st.is_connected = false;
+
+    // Run the algo
+    algo_test().expect_write(expected_request()).check(fix);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace

--- a/test/unit/test/sansio/quit_connection.cpp
+++ b/test/unit/test/sansio/quit_connection.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(ssl_error_quit)
     algo_test()
         .expect_write(expected_request(), asio::error::network_reset)
         .will_set_is_connected(false)
-        // .will_set_ssl(detail::ssl_state::inactive)
+        .will_set_ssl(detail::ssl_state::inactive)
         .check(fix, asio::error::network_reset);
 }
 

--- a/test/unit/test/sansio/quit_connection.cpp
+++ b/test/unit/test/sansio/quit_connection.cpp
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(ssl_success)
         .expect_write(expected_request())
         .expect_ssl_shutdown()
         .will_set_is_connected(false)
-        .will_set_ssl(detail::ssl_state::torn_down)
+        .will_set_ssl(detail::ssl_state::inactive)
         .check(fix);
 }
 
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(ssl_error_quit)
     algo_test()
         .expect_write(expected_request(), asio::error::network_reset)
         .will_set_is_connected(false)
-        // .will_set_ssl(detail::ssl_state::torn_down)
+        // .will_set_ssl(detail::ssl_state::inactive)
         .check(fix, asio::error::network_reset);
 }
 
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(ssl_error_shutdown)
         .expect_write(expected_request())
         .expect_ssl_shutdown(asio::error::network_reset)
         .will_set_is_connected(false)
-        .will_set_ssl(detail::ssl_state::torn_down)
+        .will_set_ssl(detail::ssl_state::inactive)
         .check(fix);  // SSL shutdown errors ignored
 }
 

--- a/test/unit/test/sansio/top_level_algo.cpp
+++ b/test/unit/test/sansio/top_level_algo.cpp
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(read_ssl_active)
     connection_state_data st(512);
     diagnostics diag;
     top_level_algo<mock_algo> algo(st, diag);
-    st.ssl = ssl_state::active;
+    st.tls_active = true;
 
     // Yielding a read with ssl active sets the use_ssl flag
     auto act = algo.resume(error_code(), 0);
@@ -402,7 +402,7 @@ BOOST_AUTO_TEST_CASE(write_ssl_active)
     connection_state_data st(0);
     diagnostics diag;
     top_level_algo<mock_algo> algo(st, diag);
-    st.ssl = ssl_state::active;
+    st.tls_active = true;
 
     // Yielding a write request when ssl_active() returns an action with the flag set
     auto act = algo.resume(error_code(), 0);


### PR DESCRIPTION
Quit now correctly marks TLS as terminated, even if it encounters an error
Removed ssl_state