### PR TITLE
Add <cstdint> to fix compilation failures with gcc-15.

### DIFF
--- a/include/boost/mysql/impl/internal/protocol/static_buffer.hpp
+++ b/include/boost/mysql/impl/internal/protocol/static_buffer.hpp
@@ -14,6 +14,7 @@
 #include <boost/core/span.hpp>
 
 #include <array>
+#include <cstdint>
 #include <cstring>
 
 namespace boost {

--- a/include/boost/mysql/metadata.hpp
+++ b/include/boost/mysql/metadata.hpp
@@ -16,6 +16,7 @@
 #include <boost/mysql/detail/flags.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <vector>
 


### PR DESCRIPTION
This fixes compilation failures we've seen in Gentoo when trying to run the boost testuite.

