### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -37,7 +37,6 @@ else()
         align
         context
         date_time
-        static_assert
         container_hash
         move
         detail


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.