### PR TITLE
Removes functional from 2ndary deps in CMake subdir test

### DIFF
--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -22,6 +22,7 @@ else()
         charconv
         compat
         config
+        container
         core
         describe
         endian
@@ -63,12 +64,10 @@ else()
         regex
         tuple
         unordered
-        container
         integer
         conversion
         function_types
         fusion
-        functional
         typeof
     )
 


### PR DESCRIPTION
Removes Boost.Functional from the CMake add_subdirectory test.
This library is no longer a secondary dependency due to an update in Fusion