### PR TITLE
Adds a way to configure the server's default charset, for tracking

### DIFF
--- a/doc/qbk/12_connection_pool.qbk
+++ b/doc/qbk/12_connection_pool.qbk
@@ -166,8 +166,9 @@ params.charset_strategy = pool_charset_strategy::use_server_default(utf8mb4_char
 
 You can obtain your server's default character set by running:
 
+[!teletype]
 ```
-select @@global.character_set_client;
+SELECT @@GLOBAL.character_set_client;
 ```
 
 

--- a/doc/qbk/12_connection_pool.qbk
+++ b/doc/qbk/12_connection_pool.qbk
@@ -125,18 +125,50 @@ affects state or not, assume it does.
 
 [heading Character set]
 
-Pooled connections always use `utf8mb4` as its character set. When connections
+By default, pooled connections use `utf8mb4` as its character set. When connections
 are reset, the equivalent of [refmem any_connection async_set_character_set] is used
 to restore the character set to `utf8mb4` (recall that raw [refmemunq any_connection async_reset_connection]
-will wipe character set data).
-
-Pooled connections always know the character set they're using.
-This means that [refmem any_connection format_opts] and [refmemunq any_connection current_character_set]
+will wipe character set data). 
+This means that, when using the defaults,
+[refmem any_connection format_opts] and [refmemunq any_connection current_character_set]
 always succeed.
 
 We recommend to always stick to `utf8mb4`. If you really need to use any other character set,
 use [refmemunq any_connection async_set_character_set] on your connection after it's been retrieved
 from the pool.
+
+[heading Avoiding SET NAMES statements on modern servers]
+
+Every time a connection is reset, [refmemunq any_connection async_reset_connection]
+causes a `SET NAMES` statement to be issued. The performance impact is minimal
+because the statement is pipelined with the reset request, but it might still
+appear in your performance data.
+
+Modern servers (MySQL 8.0+ and MariaDB 11.6+) use the `utf8mb4` character set by
+default. If you are completely sure that your server is configured to use `utf8mb4`,
+you can prevent `SET NAMES` from being used by setting [refmem pool_params charset_strategy]:
+
+```
+// TODO: move to snippets
+// Connections will no longer use SET NAMES statements,
+// and rely on the server's default to be what is passed to use_server_default.
+// You need to verify yourself that the server default matches what you pass!
+// Use this as an optimization, and only if you know what you are doing.
+pool_params params;
+params.charset_strategy = pool_charset_strategy::use_server_default(utf8mb4_charset);
+```
+
+[warning
+  When using [refmem pool_charset_strategy use_server_default], you, as a user,
+  are promising the library that your server is properly configured. This fact
+  is not checked at runtime. Use it only as an optimization if you know what you are doing.
+]
+
+You can obtain your server's default character set by running:
+
+```
+select @@global.character_set_client;
+```
 
 
 [heading Connection lifecycle]

--- a/doc/qbk/12_connection_pool.qbk
+++ b/doc/qbk/12_connection_pool.qbk
@@ -128,7 +128,7 @@ affects state or not, assume it does.
 By default, pooled connections use `utf8mb4` as its character set. When connections
 are reset, the equivalent of [refmem any_connection async_set_character_set] is used
 to restore the character set to `utf8mb4` (recall that raw [refmemunq any_connection async_reset_connection]
-will wipe character set data). 
+will wipe character set data).
 This means that, when using the defaults,
 [refmem any_connection format_opts] and [refmemunq any_connection current_character_set]
 always succeed.
@@ -148,15 +148,7 @@ Modern servers (MySQL 8.0+ and MariaDB 11.6+) use the `utf8mb4` character set by
 default. If you are completely sure that your server is configured to use `utf8mb4`,
 you can prevent `SET NAMES` from being used by setting [refmem pool_params charset_strategy]:
 
-```
-// TODO: move to snippets
-// Connections will no longer use SET NAMES statements,
-// and rely on the server's default to be what is passed to use_server_default.
-// You need to verify yourself that the server default matches what you pass!
-// Use this as an optimization, and only if you know what you are doing.
-pool_params params;
-params.charset_strategy = pool_charset_strategy::use_server_default(utf8mb4_charset);
-```
+[connection_pool_charset_strategy]
 
 [warning
   When using [refmem pool_charset_strategy use_server_default], you, as a user,

--- a/doc/qbk/17_charsets.qbk
+++ b/doc/qbk/17_charsets.qbk
@@ -170,7 +170,7 @@ Following the above points, this is how tracking works:
 ]
 
 Modern servers (MySQL 8.0+ and MariaDB 11.6+) have `utf8mb4` as the default
-character set. If you know your for sure your server's default character set,
+character set. If you know for sure your server's default character set,
 you can set it in [refmem connect_params server_default_charset].
 This changes the tracking algorithm:
 

--- a/doc/qbk/17_charsets.qbk
+++ b/doc/qbk/17_charsets.qbk
@@ -117,7 +117,8 @@ There is a number of actions that can change the connection's character set:
   available collation IDs.
   If the server recognizes the passed collation, the connection's character set
   will be the one associated to the collation. If it doesn't, the connection
-  [*will silently fall back to the server's default character set] (usually `latin1`, which is not Unicode).
+  [*will silently fall back to the server's default character set]
+  (`latin1` in old servers, which is not Unicode; and `utf8mb4` on modern servers).
   This can happen when trying to use a newer collation, like `utf8mb4_0900_ai_ci`,
   with an old MySQL 5.7 server. By default, Boost.MySQL uses
   `utf8mb4_general_ci`, supported by all servers.
@@ -168,7 +169,26 @@ Following the above points, this is how tracking works:
     information stored in the client invalid.
 ]
 
+Modern servers (MySQL 8.0+ and MariaDB 11.6+) have `utf8mb4` as the default
+character set. If you know your for sure your server's default character set,
+you can set it in [refmem connect_params default_server_charset].
+This changes the tracking algorithm:
 
+* If [refmem connect_params connection_collation] is set to [reflink invalid_collation_id],
+  after [refmemunq any_connection async_connect] succeeds, the current character
+  set is the one passed in [refmem connect_params default_server_charset].
+* Calling [refmemunq any_connection async_reset_connection]
+  sets the current character set to what was passed as
+  [refmem connect_params default_server_charset] when connecting.
+
+
+[warning
+  When setting [refmem connect_params default_server_charset], you, as a user,
+  are promising the library that your server is configured to use this character set
+  as its default one. This fact is not checked at runtime.
+  Failing to fulfill this promise can lead to vulnerabilities.
+  Use this only as an optimization if you know what you are doing.
+]
 
 
 [heading:custom Adding support for a character set]

--- a/doc/qbk/17_charsets.qbk
+++ b/doc/qbk/17_charsets.qbk
@@ -171,19 +171,19 @@ Following the above points, this is how tracking works:
 
 Modern servers (MySQL 8.0+ and MariaDB 11.6+) have `utf8mb4` as the default
 character set. If you know your for sure your server's default character set,
-you can set it in [refmem connect_params default_server_charset].
+you can set it in [refmem connect_params server_default_charset].
 This changes the tracking algorithm:
 
 * If [refmem connect_params connection_collation] is set to [reflink invalid_collation_id],
   after [refmemunq any_connection async_connect] succeeds, the current character
-  set is the one passed in [refmem connect_params default_server_charset].
+  set is the one passed in [refmem connect_params server_default_charset].
 * Calling [refmemunq any_connection async_reset_connection]
   sets the current character set to what was passed as
-  [refmem connect_params default_server_charset] when connecting.
+  [refmem connect_params server_default_charset] when connecting.
 
 
 [warning
-  When setting [refmem connect_params default_server_charset], you, as a user,
+  When setting [refmem connect_params server_default_charset], you, as a user,
   are promising the library that your server is configured to use this character set
   as its default one. This fact is not checked at runtime.
   Failing to fulfill this promise can lead to vulnerabilities.

--- a/doc/qbk/helpers/quickref.xml
+++ b/doc/qbk/helpers/quickref.xml
@@ -47,6 +47,7 @@
           <member><link linkend="mysql.ref.boost__mysql__pfr_by_name">pfr_by_name</link></member>
           <member><link linkend="mysql.ref.boost__mysql__pfr_by_position">pfr_by_position</link></member>
           <member><link linkend="mysql.ref.boost__mysql__pipeline_request">pipeline_request</link> (experimental)</member>
+          <member><link linkend="mysql.ref.boost__mysql__pool_charset_strategy">pool_charset_strategy</link></member>
           <member><link linkend="mysql.ref.boost__mysql__pool_params">pool_params</link></member>
           <member><link linkend="mysql.ref.boost__mysql__pooled_connection">pooled_connection</link></member>
           <member><link linkend="mysql.ref.boost__mysql__results">results</link></member>
@@ -74,6 +75,7 @@
           <member><link linkend="mysql.ref.boost__mysql__common_server_errc">common_server_errc</link></member>
           <member><link linkend="mysql.ref.boost__mysql__field_kind">field_kind</link></member>
           <member><link linkend="mysql.ref.boost__mysql__metadata_mode">metadata_mode</link></member>
+          <member><link linkend="mysql.ref.boost__mysql__pool_charset_strategy_type">pool_charset_strategy_type</link></member>
           <member><link linkend="mysql.ref.boost__mysql__quoting_context">quoting_context</link></member>
           <member><link linkend="mysql.ref.boost__mysql__ssl_mode">ssl_mode</link></member>
         </simplelist>
@@ -83,6 +85,7 @@
           <member><link linkend="mysql.ref.boost__mysql__default_initial_read_buffer_size">default_initial_read_buffer_size</link></member>
           <member><link linkend="mysql.ref.boost__mysql__default_port">default_port</link></member>
           <member><link linkend="mysql.ref.boost__mysql__default_port_string">default_port_string</link></member>
+          <member><link linkend="mysql.ref.boost__mysql__invalid_collation_id">invalid_collation_id</link></member>
           <member><link linkend="mysql.ref.boost__mysql__max_date">max_date</link></member>
           <member><link linkend="mysql.ref.boost__mysql__min_date">min_date</link></member>
           <member><link linkend="mysql.ref.boost__mysql__max_datetime">max_datetime</link></member>

--- a/include/boost/mysql/connect_params.hpp
+++ b/include/boost/mysql/connect_params.hpp
@@ -79,7 +79,7 @@ struct connect_params
      * \li After a successful \ref any_connection::async_reset_connection, the connection's
      *     character set is assumed to be this one (resetting restores the server's default).
      *
-     * Leave it default-constructed (the default) if you don't know the server's default
+     * Leave it value-initialized (the default) if you don't know the server's default
      * character set, in which case the above operations leave the current character set unknown.
      *
      * When you set this value, you are promising the library that your server is configured

--- a/include/boost/mysql/connect_params.hpp
+++ b/include/boost/mysql/connect_params.hpp
@@ -9,14 +9,20 @@
 #define BOOST_MYSQL_CONNECT_PARAMS_HPP
 
 #include <boost/mysql/any_address.hpp>
+#include <boost/mysql/character_set.hpp>
 #include <boost/mysql/ssl_mode.hpp>
 #include <boost/mysql/string_view.hpp>
+
+#include <boost/config.hpp>
 
 #include <cstdint>
 #include <string>
 
 namespace boost {
 namespace mysql {
+
+// TODO: document and maybe move? Do we need it?
+BOOST_INLINE_CONSTEXPR std::uint16_t invalid_collation_id = 0u;
 
 /**
  * \brief Parameters to be used with \ref any_connection connect functions.
@@ -64,6 +70,8 @@ struct connect_params
      * \details Disabled by default.
      */
     bool multi_queries{false};
+
+    character_set server_default_charset{};
 };
 
 }  // namespace mysql

--- a/include/boost/mysql/connect_params.hpp
+++ b/include/boost/mysql/connect_params.hpp
@@ -66,6 +66,27 @@ struct connect_params
      */
     bool multi_queries{false};
 
+    /**
+     * \brief The character set that the server uses as its default.
+     * \details
+     * Set this value if you know the character set that your server is configured to use
+     * by default, as an optimization. It affects how the connection tracks its current
+     * character set (see \ref any_connection::current_character_set):
+     *
+     * \li If \ref connection_collation is set to \ref invalid_collation_id,
+     *     after connection establishment, the connection's character set is assumed to be
+     *     this one.
+     * \li After a successful \ref any_connection::async_reset_connection, the connection's
+     *     character set is assumed to be this one (resetting restores the server's default).
+     *
+     * Leave it default-constructed (the default) if you don't know the server's default
+     * character set, in which case the above operations leave the current character set unknown.
+     *
+     * When you set this value, you are promising the library that your server is configured
+     * to use this character set as its default. This is not checked at runtime, and failing
+     * to fulfill this promise can lead to vulnerabilities. Use it only as an optimization if
+     * you know what you are doing.
+     */
     character_set server_default_charset{};
 };
 

--- a/include/boost/mysql/connect_params.hpp
+++ b/include/boost/mysql/connect_params.hpp
@@ -13,16 +13,11 @@
 #include <boost/mysql/ssl_mode.hpp>
 #include <boost/mysql/string_view.hpp>
 
-#include <boost/config.hpp>
-
 #include <cstdint>
 #include <string>
 
 namespace boost {
 namespace mysql {
-
-// TODO: document and maybe move? Do we need it?
-BOOST_INLINE_CONSTEXPR std::uint16_t invalid_collation_id = 0u;
 
 /**
  * \brief Parameters to be used with \ref any_connection connect functions.

--- a/include/boost/mysql/defaults.hpp
+++ b/include/boost/mysql/defaults.hpp
@@ -25,7 +25,16 @@ BOOST_INLINE_CONSTEXPR const char* default_port_string = "3306";
 /// The default initial size of the connection's internal buffer, in bytes.
 BOOST_INLINE_CONSTEXPR std::size_t default_initial_read_buffer_size = 1024;
 
-// TODO: document
+/**
+ * \brief A collation ID that is never valid.
+ * \details
+ * Pass this value as \ref connect_params::connection_collation to set the
+ * connection's character set and collation to the server's defaults.
+ * Run `select @@global.character_set_client;` to find out the server's
+ * default character set.
+ *
+ * This is intended to be used together with \ref connect_params::server_default_charset.
+ */
 BOOST_INLINE_CONSTEXPR std::uint16_t invalid_collation_id = 0u;
 
 }  // namespace mysql

--- a/include/boost/mysql/defaults.hpp
+++ b/include/boost/mysql/defaults.hpp
@@ -30,7 +30,7 @@ BOOST_INLINE_CONSTEXPR std::size_t default_initial_read_buffer_size = 1024;
  * \details
  * Pass this value as \ref connect_params::connection_collation to set the
  * connection's character set and collation to the server's defaults.
- * Run `select @@global.character_set_client;` to find out the server's
+ * Run `"SELECT @@GLOBAL.character_set_client;"` to find out the server's
  * default character set.
  *
  * This is intended to be used together with \ref connect_params::server_default_charset.

--- a/include/boost/mysql/defaults.hpp
+++ b/include/boost/mysql/defaults.hpp
@@ -11,6 +11,7 @@
 #include <boost/config.hpp>
 
 #include <cstddef>
+#include <cstdint>
 
 namespace boost {
 namespace mysql {
@@ -23,6 +24,9 @@ BOOST_INLINE_CONSTEXPR const char* default_port_string = "3306";
 
 /// The default initial size of the connection's internal buffer, in bytes.
 BOOST_INLINE_CONSTEXPR std::size_t default_initial_read_buffer_size = 1024;
+
+// TODO: document
+BOOST_INLINE_CONSTEXPR std::uint16_t invalid_collation_id = 0u;
 
 }  // namespace mysql
 }  // namespace boost

--- a/include/boost/mysql/detail/algo_params.hpp
+++ b/include/boost/mysql/detail/algo_params.hpp
@@ -40,6 +40,7 @@ struct connect_algo_params
                                  // the templated connection, only valid until the first yield!
     handshake_params hparams;
     bool secure_channel;  // Are we using UNIX sockets or any other secure channel?
+    character_set server_default_charset;
 
     using result_type = void;
 };
@@ -48,6 +49,7 @@ struct handshake_algo_params
 {
     handshake_params hparams;
     bool secure_channel;  // Are we using UNIX sockets or any other secure channel?
+    character_set server_default_charset;
 
     using result_type = void;
 };

--- a/include/boost/mysql/detail/connection_impl.hpp
+++ b/include/boost/mysql/detail/connection_impl.hpp
@@ -225,7 +225,7 @@ class connection_impl
     // Connect
     static connect_algo_params make_params_connect(const void* server_address, const handshake_params& params)
     {
-        return connect_algo_params{server_address, params, false};
+        return connect_algo_params{server_address, params, false, {}};
     }
 
     static connect_algo_params make_params_connect_v2(const connect_params& params)
@@ -233,7 +233,8 @@ class connection_impl
         return connect_algo_params{
             &params.server_address,
             make_hparams(params),
-            params.server_address.type() == address_type::unix_path
+            params.server_address.type() == address_type::unix_path,
+            params.server_default_charset,
         };
     }
 
@@ -453,7 +454,7 @@ public:
     // Handshake
     handshake_algo_params make_params_handshake(const handshake_params& params) const
     {
-        return {params, false};
+        return {params, false, {}};
     }
 
     // Execute

--- a/include/boost/mysql/impl/internal/connection_pool/connection_node.hpp
+++ b/include/boost/mysql/impl/internal/connection_pool/connection_node.hpp
@@ -98,7 +98,6 @@ class basic_connection_node : public intrusive::list_base_hook<>,
     diagnostics connect_diag_;
     timer_type collection_timer_;  // Notifications about collections. A separate timer makes potential race
                                    // conditions not harmful
-    const pipeline_request* reset_pipeline_req_;
     std::vector<stage_response> reset_pipeline_res_;
 
     // Thread-safe
@@ -190,7 +189,7 @@ class basic_connection_node : public intrusive::list_base_hook<>,
             case next_connection_action::reset:
                 node_.run_with_timeout(
                     node_.conn_.async_run_pipeline(
-                        *node_.reset_pipeline_req_,
+                        node_.params_->reset_pipeline,
                         node_.reset_pipeline_res_,
                         asio::deferred
                     ),
@@ -219,15 +218,13 @@ public:
         internal_pool_params& params,
         boost::asio::any_io_executor pool_ex,
         boost::asio::any_io_executor conn_ex,
-        conn_shared_state<ConnectionType, ClockType>& shared_st,
-        const pipeline_request* reset_pipeline_req
+        conn_shared_state<ConnectionType, ClockType>& shared_st
     )
         : params_(&params),
           shared_st_(&shared_st),
           conn_(std::move(conn_ex), params.make_ctor_params()),
           timer_(pool_ex),
-          collection_timer_(pool_ex, (std::chrono::steady_clock::time_point::max)()),
-          reset_pipeline_req_(reset_pipeline_req)
+          collection_timer_(pool_ex, (std::chrono::steady_clock::time_point::max)())
     {
     }
 

--- a/include/boost/mysql/impl/internal/connection_pool/connection_pool_impl.hpp
+++ b/include/boost/mysql/impl/internal/connection_pool/connection_pool_impl.hpp
@@ -48,13 +48,6 @@ namespace boost {
 namespace mysql {
 namespace detail {
 
-inline pipeline_request make_reset_pipeline()
-{
-    pipeline_request req;
-    req.add_reset_connection().add_set_character_set(utf8mb4_charset);
-    return req;
-}
-
 // Templating on ConnectionWrapper is useful for mocking in tests.
 // Production code always uses ConnectionWrapper = pooled_connection.
 template <class ConnectionType, class ClockType, class ConnectionWrapper>
@@ -90,7 +83,6 @@ class basic_pool_impl
     std::list<node_type> all_conns_;
     shared_state_type shared_st_;
     timer_type cancel_timer_;
-    const pipeline_request reset_pipeline_req_{make_reset_pipeline()};
 
     std::shared_ptr<this_type> shared_from_this_wrapper()
     {
@@ -102,7 +94,7 @@ class basic_pool_impl
     void create_connection()
     {
         // Connection tasks always run in the pool's executor
-        all_conns_.emplace_back(params_, pool_ex_, conn_ex_, shared_st_, &reset_pipeline_req_);
+        all_conns_.emplace_back(params_, pool_ex_, conn_ex_, shared_st_, &params_.reset_pipeline);
         all_conns_.back().async_run(asio::bind_executor(pool_ex_, asio::detached));
     }
 
@@ -599,7 +591,6 @@ public:
     shared_state_type& shared_state() noexcept { return shared_st_; }
     internal_pool_params& params() noexcept { return params_; }
     asio::any_io_executor connection_ex() noexcept { return conn_ex_; }
-    const pipeline_request& reset_pipeline_request() const { return reset_pipeline_req_; }
 };
 
 }  // namespace detail

--- a/include/boost/mysql/impl/internal/connection_pool/connection_pool_impl.hpp
+++ b/include/boost/mysql/impl/internal/connection_pool/connection_pool_impl.hpp
@@ -94,7 +94,7 @@ class basic_pool_impl
     void create_connection()
     {
         // Connection tasks always run in the pool's executor
-        all_conns_.emplace_back(params_, pool_ex_, conn_ex_, shared_st_, &params_.reset_pipeline);
+        all_conns_.emplace_back(params_, pool_ex_, conn_ex_, shared_st_);
         all_conns_.back().async_run(asio::bind_executor(pool_ex_, asio::detached));
     }
 

--- a/include/boost/mysql/impl/internal/connection_pool/internal_pool_params.hpp
+++ b/include/boost/mysql/impl/internal/connection_pool/internal_pool_params.hpp
@@ -9,8 +9,10 @@
 #define BOOST_MYSQL_IMPL_INTERNAL_CONNECTION_POOL_INTERNAL_POOL_PARAMS_HPP
 
 #include <boost/mysql/any_connection.hpp>
+#include <boost/mysql/character_set.hpp>
 #include <boost/mysql/connect_params.hpp>
 #include <boost/mysql/handshake_params.hpp>
+#include <boost/mysql/pipeline.hpp>
 #include <boost/mysql/pool_params.hpp>
 #include <boost/mysql/ssl_mode.hpp>
 
@@ -31,6 +33,7 @@ namespace detail {
 struct internal_pool_params
 {
     connect_params connect_config;
+    pipeline_request reset_pipeline;
     optional<asio::ssl::context> ssl_ctx;
     std::size_t initial_buffer_size;
     std::size_t initial_size;
@@ -83,9 +86,22 @@ inline internal_pool_params make_internal_pool_params(pool_params&& params)
     connect_prms.database = std::move(params.database);
     connect_prms.ssl = params.ssl;
     connect_prms.multi_queries = params.multi_queries;
+    if (params.charset_strategy.type() == pool_charset_strategy_type::use_server_default)
+    {
+        // Intentionally invalid, to force the server use its default.
+        // We can't allow otherwise because resetting sets the collation back to the default.
+        connect_prms.connection_collation = invalid_collation_id;
+        connect_prms.server_default_charset = params.charset_strategy.server_default_charset();
+    }
+
+    pipeline_request reset_pipe;
+    reset_pipe.add_reset_connection();
+    if (params.charset_strategy.type() == pool_charset_strategy_type::set_to_utf8mb4)
+        reset_pipe.add_set_character_set(utf8mb4_charset);
 
     return {
         std::move(connect_prms),
+        std::move(reset_pipe),
         std::move(params.ssl_ctx),
         params.initial_buffer_size,
         params.initial_size,

--- a/include/boost/mysql/impl/internal/connection_pool/internal_pool_params.hpp
+++ b/include/boost/mysql/impl/internal/connection_pool/internal_pool_params.hpp
@@ -11,6 +11,7 @@
 #include <boost/mysql/any_connection.hpp>
 #include <boost/mysql/character_set.hpp>
 #include <boost/mysql/connect_params.hpp>
+#include <boost/mysql/defaults.hpp>
 #include <boost/mysql/handshake_params.hpp>
 #include <boost/mysql/pipeline.hpp>
 #include <boost/mysql/pool_params.hpp>

--- a/include/boost/mysql/impl/internal/sansio/connect.hpp
+++ b/include/boost/mysql/impl/internal/sansio/connect.hpp
@@ -31,7 +31,8 @@ class connect_algo
 
 public:
     connect_algo(connect_algo_params params) noexcept
-        : server_address_(params.server_address), handshake_({params.hparams, params.secure_channel})
+        : server_address_(params.server_address),
+          handshake_({params.hparams, params.secure_channel, params.server_default_charset})
     {
     }
 

--- a/include/boost/mysql/impl/internal/sansio/connection_state_data.hpp
+++ b/include/boost/mysql/impl/internal/sansio/connection_state_data.hpp
@@ -88,7 +88,6 @@ struct connection_state_data
 
     // The server's default character set, or a value-initialized one if unknown.
     // This may be passed by the user as an optimization.
-    // TODO: account for this in tests
     character_set server_default_charset{};
 
     // The current character set, or a value-initialized one if unknown

--- a/include/boost/mysql/impl/internal/sansio/connection_state_data.hpp
+++ b/include/boost/mysql/impl/internal/sansio/connection_state_data.hpp
@@ -86,7 +86,12 @@ struct connection_state_data
     // be disabled using a variable. OK packets include a flag with this info.
     bool backslash_escapes{true};
 
-    // The current character set, or a default-constructed character set (will all nullptrs) if unknown
+    // The server's default character set, or a value-initialized one if unknown.
+    // This may be passed by the user as an optimization.
+    // TODO: account for this in tests
+    character_set server_default_charset{};
+
+    // The current character set, or a value-initialized one if unknown
     character_set current_charset{};
 
     // The write buffer

--- a/include/boost/mysql/impl/internal/sansio/connection_state_data.hpp
+++ b/include/boost/mysql/impl/internal/sansio/connection_state_data.hpp
@@ -123,6 +123,7 @@ struct connection_state_data
         tls_active = false;
         backslash_escapes = true;
         current_charset = character_set{};
+        server_default_charset = character_set{};
     }
 
     // Reads an OK packet from the reader. This operation is repeated in several places.

--- a/include/boost/mysql/impl/internal/sansio/handshake.hpp
+++ b/include/boost/mysql/impl/internal/sansio/handshake.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/mysql/character_set.hpp>
 #include <boost/mysql/client_errc.hpp>
+#include <boost/mysql/defaults.hpp>
 #include <boost/mysql/diagnostics.hpp>
 #include <boost/mysql/error_code.hpp>
 #include <boost/mysql/handshake_params.hpp>
@@ -211,7 +212,7 @@ class handshake_algo
     {
         switch (collation_id)
         {
-        case 0: return server_default_charset;  // zero is always an invalid collation ID
+        case invalid_collation_id: return server_default_charset;
         case mysql_collations::utf8mb4_bin:
         case mysql_collations::utf8mb4_general_ci: return utf8mb4_charset;
         case mysql_collations::ascii_general_ci:

--- a/include/boost/mysql/impl/internal/sansio/handshake.hpp
+++ b/include/boost/mysql/impl/internal/sansio/handshake.hpp
@@ -138,7 +138,7 @@ class handshake_algo
     std::array<std::uint8_t, scramble_size> scramble_;
     std::uint8_t sequence_number_{0};
     bool secure_channel_{false};
-    character_set server_default_charset_;
+    character_set server_default_charset_{};
 
     static capabilities conditional_capability(bool condition, capabilities cap)
     {

--- a/include/boost/mysql/impl/internal/sansio/handshake.hpp
+++ b/include/boost/mysql/impl/internal/sansio/handshake.hpp
@@ -138,6 +138,7 @@ class handshake_algo
     std::array<std::uint8_t, scramble_size> scramble_;
     std::uint8_t sequence_number_{0};
     bool secure_channel_{false};
+    character_set server_default_charset_;
 
     static capabilities conditional_capability(bool condition, capabilities cap)
     {
@@ -203,10 +204,14 @@ class handshake_algo
     // Attempts to map the collection_id to a character set. We try to be conservative
     // here, since servers will happily accept unknown collation IDs, silently defaulting
     // to the server's default character set (often latin1, which is not Unicode).
-    static character_set collation_id_to_charset(std::uint16_t collation_id)
+    static character_set collation_id_to_charset(
+        character_set server_default_charset,
+        std::uint16_t collation_id
+    )
     {
         switch (collation_id)
         {
+        case 0: return server_default_charset;  // zero is always an invalid collation ID
         case mysql_collations::utf8mb4_bin:
         case mysql_collations::utf8mb4_general_ci: return utf8mb4_charset;
         case mysql_collations::ascii_general_ci:
@@ -311,7 +316,11 @@ class handshake_algo
     {
         st.status = connection_status::ready;
         st.backslash_escapes = ok.backslash_escapes();
-        st.current_charset = collation_id_to_charset(hparams_.connection_collation());
+        st.server_default_charset = server_default_charset_;
+        st.current_charset = collation_id_to_charset(
+            server_default_charset_,
+            hparams_.connection_collation()
+        );
     }
 
     next_action resume_impl(connection_state_data& st, diagnostics& diag, error_code ec)
@@ -437,7 +446,9 @@ class handshake_algo
 
 public:
     handshake_algo(handshake_algo_params params) noexcept
-        : hparams_(params.hparams), secure_channel_(params.secure_channel)
+        : hparams_(params.hparams),
+          secure_channel_(params.secure_channel),
+          server_default_charset_(params.server_default_charset)
     {
     }
 

--- a/include/boost/mysql/impl/internal/sansio/reset_connection.hpp
+++ b/include/boost/mysql/impl/internal/sansio/reset_connection.hpp
@@ -46,9 +46,9 @@ public:
             if (!ec)
             {
                 // Reset was successful. Resetting changes the connection's character set
-                // to the server's default, which is an unknown value that doesn't have to match
-                // what was specified in handshake. As a safety measure, clear the current charset
-                st.current_charset = character_set{};
+                // to the server's default, which is an unknown value unless the user specified
+                // it during handshake.
+                st.current_charset = st.server_default_charset;
             }
 
             // Done

--- a/include/boost/mysql/pool_params.hpp
+++ b/include/boost/mysql/pool_params.hpp
@@ -11,10 +11,12 @@
 #include <boost/mysql/any_address.hpp>
 #include <boost/mysql/character_set.hpp>
 #include <boost/mysql/defaults.hpp>
+#include <boost/mysql/pipeline.hpp>
 #include <boost/mysql/ssl_mode.hpp>
 
 #include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/ssl/context.hpp>
+#include <boost/assert.hpp>
 #include <boost/optional/optional.hpp>
 
 #include <chrono>
@@ -32,15 +34,30 @@ enum class pool_charset_strategy_type
 
 class pool_charset_strategy
 {
+    pool_charset_strategy_type type_{pool_charset_strategy_type::set_to_utf8mb4};
+    character_set server_default_charset_{};
+
+    explicit pool_charset_strategy(character_set c)
+        : type_(pool_charset_strategy_type::use_server_default), server_default_charset_(c)
+    {
+    }
+
 public:
     pool_charset_strategy() = default;
 
-    static pool_charset_strategy set_to_utf8mb4() { return {}; }
-    static pool_charset_strategy use_server_default(character_set charset);
+    static inline pool_charset_strategy set_to_utf8mb4() noexcept { return {}; }
+    static inline pool_charset_strategy use_server_default(character_set charset) noexcept
+    {
+        return pool_charset_strategy(charset);
+    }
 
-    pool_charset_strategy_type type() const;
+    pool_charset_strategy_type type() const noexcept { return type_; }
 
-    character_set server_default_charset() const;
+    character_set server_default_charset() const noexcept
+    {
+        BOOST_ASSERT(type_ == pool_charset_strategy_type::use_server_default);
+        return server_default_charset_;
+    }
 };
 
 /**

--- a/include/boost/mysql/pool_params.hpp
+++ b/include/boost/mysql/pool_params.hpp
@@ -26,12 +26,37 @@
 namespace boost {
 namespace mysql {
 
+/// Type tag for \ref pool_charset_strategy.
 enum class pool_charset_strategy_type
 {
+    /// Connections are set to use `utf8mb4` explicitly.
     set_to_utf8mb4,
+
+    /// Connections use the server's default character set, which is supplied by the user.
     use_server_default,
 };
 
+/**
+ * \brief Describes how pooled connections manage their character set.
+ * \details
+ * This is a lightweight variant-like type that determines how connections in a pool
+ * set its character set and restore it when they are returned
+ * to the pool. Create instances using the \ref set_to_utf8mb4 and \ref use_server_default
+ * factory functions.
+ *
+ * \li When using \ref set_to_utf8mb4 (the default), connections are established using
+ *     a collation ID of `utf8mb4_general_ci`, and a `SET NAMES` statement is issued
+ *     after returning them to the pool and resetting them. The character set is always
+ *     known and equal to `utf8mb4`.
+ * \li When using \ref use_server_default, connections are established using
+ *     \ref invalid_collation_id as collation ID, causing them to use the server's default.
+ *     No `SET NAMES` statement is issued after resetting the connections,
+ *     causing them again to use the server's default.
+ *     When using this value, you must provide the server's default character set
+ *     as an argument, and it must match what is actually configured in the server
+ *     (no runtime check is performed). This option should only be used as an optimization,
+ *     and if you know what you are doing.
+ */
 class pool_charset_strategy
 {
     pool_charset_strategy_type type_{pool_charset_strategy_type::set_to_utf8mb4};
@@ -43,16 +68,61 @@ class pool_charset_strategy
     }
 
 public:
+    /**
+     * \brief Default constructor, equivalent to \ref set_to_utf8mb4.
+     *
+     * \par Exception safety
+     * No-throw guarantee.
+     */
     pool_charset_strategy() = default;
 
+    /**
+     * \brief Creates a strategy that makes pooled connections use `utf8mb4`.
+     * \details
+     * Creates an object with type \ref pool_charset_strategy_type::set_to_utf8mb4.
+     *
+     * \par Exception safety
+     * No-throw guarantee.
+     */
     static inline pool_charset_strategy set_to_utf8mb4() noexcept { return {}; }
+
+    /**
+     * \brief Creates a strategy that makes pooled connections use the server's default character set.
+     * \details
+     * Creates an object with type \ref pool_charset_strategy_type::use_server_default
+     * and a \ref server_default_charset equal to the passed charset.
+     *
+     * The passed `charset` must equal the server's configured default character set.
+     * No runtime check is performed to verify this assertion. If it does not hold,
+     * vulnerabilities may arise. If unsure, prefer \ref set_to_utf8mb4.
+     *
+     * \par Exception safety
+     * No-throw guarantee.
+     */
     static inline pool_charset_strategy use_server_default(character_set charset) noexcept
     {
         return pool_charset_strategy(charset);
     }
 
+    /**
+     * \brief Retrieves the kind of strategy represented by this object.
+     *
+     * \par Exception safety
+     * No-throw guarantee.
+     */
     pool_charset_strategy_type type() const noexcept { return type_; }
 
+    /**
+     * \brief Retrieves the server's default character set.
+     *
+     * \details Returns the character set that was passed to \ref use_server_default.
+     *
+     * \par Preconditions
+     * `this->type() == pool_charset_strategy_type::use_server_default`
+     *
+     * \par Exception safety
+     * No-throw guarantee.
+     */
     character_set server_default_charset() const noexcept
     {
         BOOST_ASSERT(type_ == pool_charset_strategy_type::use_server_default);
@@ -230,6 +300,16 @@ struct pool_params
      */
     asio::any_io_executor connection_executor{};
 
+    /**
+     * \brief Determines the character set used by connections created by the pool.
+     * \details
+     * Controls how pooled connections manage their character set.
+     * Defaults to \ref pool_charset_strategy::set_to_utf8mb4,
+     * which makes all connections use `utf8mb4` by setting it explicitly.
+     *
+     * This is an advanced setting. Please read how character set tracking works
+     * before changing it.
+     */
     pool_charset_strategy charset_strategy{};
 };
 

--- a/include/boost/mysql/pool_params.hpp
+++ b/include/boost/mysql/pool_params.hpp
@@ -9,6 +9,7 @@
 #define BOOST_MYSQL_POOL_PARAMS_HPP
 
 #include <boost/mysql/any_address.hpp>
+#include <boost/mysql/character_set.hpp>
 #include <boost/mysql/defaults.hpp>
 #include <boost/mysql/ssl_mode.hpp>
 
@@ -22,6 +23,25 @@
 
 namespace boost {
 namespace mysql {
+
+enum class pool_charset_strategy_type
+{
+    set_to_utf8mb4,
+    use_server_default,
+};
+
+class pool_charset_strategy
+{
+public:
+    pool_charset_strategy() = default;
+
+    static pool_charset_strategy set_to_utf8mb4() { return {}; }
+    static pool_charset_strategy use_server_default(character_set charset);
+
+    pool_charset_strategy_type type() const;
+
+    character_set server_default_charset() const;
+};
 
 /**
  * \brief Configuration parameters for \ref connection_pool.
@@ -192,6 +212,8 @@ struct pool_params
      * (as per \ref connection_pool::get_executor).
      */
     asio::any_io_executor connection_executor{};
+
+    pool_charset_strategy charset_strategy{};
 };
 
 }  // namespace mysql

--- a/test/integration/include/test_integration/connect_params_builder.hpp
+++ b/test/integration/include/test_integration/connect_params_builder.hpp
@@ -9,6 +9,7 @@
 #define BOOST_MYSQL_TEST_INTEGRATION_INCLUDE_TEST_INTEGRATION_CONNECT_PARAMS_BUILDER_HPP
 
 #include <boost/mysql/any_address.hpp>
+#include <boost/mysql/character_set.hpp>
 #include <boost/mysql/connect_params.hpp>
 #include <boost/mysql/handshake_params.hpp>
 #include <boost/mysql/metadata_collection_view.hpp>
@@ -28,6 +29,7 @@ class connect_params_builder
 {
     handshake_params res_{integ_user, integ_passwd, integ_db};
     any_address addr_;
+    character_set default_server_charset_{};
 
 public:
     connect_params_builder() { addr_.emplace_host_and_port(get_hostname()); }
@@ -74,6 +76,12 @@ public:
     connect_params_builder& collation(std::uint16_t v)
     {
         res_.set_connection_collation(v);
+        return *this;
+    }
+
+    connect_params_builder& default_server_charset(character_set v)
+    {
+        default_server_charset_ = v;
         return *this;
     }
 

--- a/test/integration/include/test_integration/connect_params_builder.hpp
+++ b/test/integration/include/test_integration/connect_params_builder.hpp
@@ -29,7 +29,7 @@ class connect_params_builder
 {
     handshake_params res_{integ_user, integ_passwd, integ_db};
     any_address addr_;
-    character_set default_server_charset_{};
+    character_set server_default_charset_{};
 
 public:
     connect_params_builder() { addr_.emplace_host_and_port(get_hostname()); }
@@ -79,9 +79,9 @@ public:
         return *this;
     }
 
-    connect_params_builder& default_server_charset(character_set v)
+    connect_params_builder& server_default_charset(character_set v)
     {
-        default_server_charset_ = v;
+        server_default_charset_ = v;
         return *this;
     }
 

--- a/test/integration/src/utils.cpp
+++ b/test/integration/src/utils.cpp
@@ -108,6 +108,7 @@ connect_params connect_params_builder::build()
     res.multi_queries = res_.multi_queries();
     res.ssl = res_.ssl();
     res.connection_collation = res_.connection_collation();
+    res.server_default_charset = default_server_charset_;
     return res;
 }
 

--- a/test/integration/src/utils.cpp
+++ b/test/integration/src/utils.cpp
@@ -108,7 +108,7 @@ connect_params connect_params_builder::build()
     res.multi_queries = res_.multi_queries();
     res.ssl = res_.ssl();
     res.connection_collation = res_.connection_collation();
-    res.server_default_charset = default_server_charset_;
+    res.server_default_charset = server_default_charset_;
     return res;
 }
 

--- a/test/integration/test/character_set_tracking.cpp
+++ b/test/integration/test/character_set_tracking.cpp
@@ -142,7 +142,7 @@ BOOST_FIXTURE_TEST_CASE(connect_with_unknown_collation_server_default, any_conne
     connect(
         connect_params_builder()
             .collation(mysql_collations::utf8mb4_0900_ai_ci)
-            .default_server_charset(ascii_charset)
+            .server_default_charset(ascii_charset)
             .build()
     );
     BOOST_TEST(conn.current_character_set().error() == client_errc::unknown_character_set);
@@ -174,7 +174,7 @@ BOOST_FIXTURE_TEST_CASE(connect_with_invalid_collation_id, any_connection_fixtur
 BOOST_FIXTURE_TEST_CASE(connect_with_invalid_collation_id_server_default, any_connection_fixture)
 {
     connect(
-        connect_params_builder().collation(invalid_collation_id).default_server_charset(ascii_charset).build()
+        connect_params_builder().collation(invalid_collation_id).server_default_charset(ascii_charset).build()
     );
     BOOST_TEST(conn.current_character_set() == ascii_charset);
 
@@ -190,7 +190,7 @@ BOOST_FIXTURE_TEST_CASE(connect_with_invalid_collation_id_server_default, any_co
 BOOST_FIXTURE_TEST_CASE(reset_with_server_default, any_connection_fixture)
 {
     // Connect with a known character set. Specify the server's default
-    connect(connect_params_builder().default_server_charset(ascii_charset).build());
+    connect(connect_params_builder().server_default_charset(ascii_charset).build());
     BOOST_TEST(conn.current_character_set() == utf8mb4_charset);
 
     // Resetting sets the charset to the server's default.

--- a/test/integration/test/character_set_tracking.cpp
+++ b/test/integration/test/character_set_tracking.cpp
@@ -134,6 +134,26 @@ BOOST_FIXTURE_TEST_CASE(connect_with_unknown_collation, any_connection_fixture)
     validate_db_charset(conn, "ascii");
 }
 
+// Supplying a server default has no effect when the collation may be unknown
+BOOST_FIXTURE_TEST_CASE(connect_with_unknown_collation_server_default, any_connection_fixture)
+{
+    // Connect with a collation that some servers may not support, or that we don't know of
+    // utf8mb4_0900_ai_ci is not supported by MariaDB, triggers fallback
+    connect(
+        connect_params_builder()
+            .collation(mysql_collations::utf8mb4_0900_ai_ci)
+            .default_server_charset(ascii_charset)
+            .build()
+    );
+    BOOST_TEST(conn.current_character_set().error() == client_errc::unknown_character_set);
+    BOOST_TEST(conn.format_opts().error() == client_errc::unknown_character_set);
+
+    // Explicitly setting the character set solves the issue
+    conn.async_set_character_set(ascii_charset, as_netresult).validate_no_error();
+    BOOST_TEST(conn.current_character_set()->name == "ascii");
+    validate_db_charset(conn, "ascii");
+}
+
 // Connecting with invalid_collation_id falls back to the server's default charset
 // and leaves us with an unknown charset
 BOOST_FIXTURE_TEST_CASE(connect_with_invalid_collation_id, any_connection_fixture)
@@ -165,7 +185,23 @@ BOOST_FIXTURE_TEST_CASE(connect_with_invalid_collation_id_server_default, any_co
     BOOST_TEST(r.rows().at(0).at(0) == r.rows().at(0).at(1));
 }
 
-// Resetting after having connected specifying the server's default sets
-//    the value accordingly
+// Resetting after having connected specifying the server's default makes
+// tracking use this value, instead of clearing it.
+BOOST_FIXTURE_TEST_CASE(reset_with_server_default, any_connection_fixture)
+{
+    // Connect with a known character set. Specify the server's default
+    connect(connect_params_builder().default_server_charset(ascii_charset).build());
+    BOOST_TEST(conn.current_character_set() == utf8mb4_charset);
+
+    // Resetting sets the charset to the server's default.
+    // Because we specified a server's default charset, tracking uses it.
+    conn.async_reset_connection(as_netresult).validate_no_error();
+    BOOST_TEST(conn.current_character_set() == ascii_charset);
+
+    results r;
+    conn.async_execute("SELECT @@GLOBAL.character_set_client, @@character_set_client", r, as_netresult)
+        .validate_no_error();
+    BOOST_TEST(r.rows().at(0).at(0) == r.rows().at(0).at(1));
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/integration/test/character_set_tracking.cpp
+++ b/test/integration/test/character_set_tracking.cpp
@@ -8,6 +8,7 @@
 #include <boost/mysql/any_connection.hpp>
 #include <boost/mysql/character_set.hpp>
 #include <boost/mysql/client_errc.hpp>
+#include <boost/mysql/defaults.hpp>
 #include <boost/mysql/mysql_collations.hpp>
 #include <boost/mysql/results.hpp>
 #include <boost/mysql/ssl_mode.hpp>
@@ -132,5 +133,39 @@ BOOST_FIXTURE_TEST_CASE(connect_with_unknown_collation, any_connection_fixture)
     BOOST_TEST(conn.current_character_set()->name == "ascii");
     validate_db_charset(conn, "ascii");
 }
+
+// Connecting with invalid_collation_id falls back to the server's default charset
+// and leaves us with an unknown charset
+BOOST_FIXTURE_TEST_CASE(connect_with_invalid_collation_id, any_connection_fixture)
+{
+    connect(connect_params_builder().collation(invalid_collation_id).build());
+    BOOST_TEST(conn.current_character_set().error() == client_errc::unknown_character_set);
+    BOOST_TEST(conn.format_opts().error() == client_errc::unknown_character_set);
+
+    // The server is always using its default value
+    results r;
+    conn.async_execute("SELECT @@GLOBAL.character_set_client, @@character_set_client", r, as_netresult)
+        .validate_no_error();
+    BOOST_TEST(r.rows().at(0).at(0) == r.rows().at(0).at(1));
+}
+
+// Specifying the server's default charset and invalid_collation_id tells
+// tracking which charset it should be using
+BOOST_FIXTURE_TEST_CASE(connect_with_invalid_collation_id_server_default, any_connection_fixture)
+{
+    connect(
+        connect_params_builder().collation(invalid_collation_id).default_server_charset(ascii_charset).build()
+    );
+    BOOST_TEST(conn.current_character_set() == ascii_charset);
+
+    // The server is always using its default value
+    results r;
+    conn.async_execute("SELECT @@GLOBAL.character_set_client, @@character_set_client", r, as_netresult)
+        .validate_no_error();
+    BOOST_TEST(r.rows().at(0).at(0) == r.rows().at(0).at(1));
+}
+
+// Resetting after having connected specifying the server's default sets
+//    the value accordingly
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/integration/test/connection_pool.cpp
+++ b/test/integration/test/connection_pool.cpp
@@ -767,7 +767,6 @@ BOOST_FIXTURE_TEST_CASE(charset_strategy_use_server_default, fixture)
     BOOST_TEST(conn->current_character_set() == greek_charset);
 
     // The connection is using the server's default (this is different across versions)
-    results r;
     conn->async_execute("SELECT @@GLOBAL.character_set_client, @@character_set_client", r, as_netresult)
         .validate_no_error();
     std::string server_default = r.rows().at(0).at(0).as_string();

--- a/test/integration/test/connection_pool.cpp
+++ b/test/integration/test/connection_pool.cpp
@@ -6,10 +6,12 @@
 //
 
 #include <boost/mysql/any_connection.hpp>
+#include <boost/mysql/character_set.hpp>
 #include <boost/mysql/client_errc.hpp>
 #include <boost/mysql/connection_pool.hpp>
 #include <boost/mysql/diagnostics.hpp>
 #include <boost/mysql/error_code.hpp>
+#include <boost/mysql/field_view.hpp>
 #include <boost/mysql/pool_params.hpp>
 #include <boost/mysql/results.hpp>
 #include <boost/mysql/ssl_mode.hpp>
@@ -33,6 +35,7 @@
 #include <exception>
 #include <memory>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 #include "test_common/ci_server.hpp"
@@ -738,6 +741,59 @@ BOOST_FIXTURE_TEST_CASE(cancel_after_partial_token, fixture)
 }
 
 #endif
+
+// Using a charset strategy of use_server_default makes us
+//   - Request the server's default charset when connecting
+//   - Suppress SET NAMES when resetting
+//   - Assume that the server's charset is the one passed by the user
+BOOST_FIXTURE_TEST_CASE(charset_strategy_use_server_default, fixture)
+{
+    // A dummy character set for testing purposes
+    character_set greek_charset{"greek", ascii_charset.next_char};
+
+    // Create a pool with max_size 1, so the same connection gets always returned.
+    // Set the charset to something different than utf8mb4. This is not what the server
+    // is actually using, but allows us to test that we trust the user.
+    auto params = create_pool_params(1);
+    params.charset_strategy = pool_charset_strategy::use_server_default(greek_charset);
+    connection_pool pool(ctx, std::move(params));
+    auto run_result = pool.async_run(as_netresult);
+
+    // Get a connection
+    auto conn = pool.async_get_connection(diag, as_netresult).get();
+    BOOST_TEST_REQUIRE(conn.valid());
+
+    // The connection thinks it's using the charset we supplied
+    BOOST_TEST(conn->current_character_set() == greek_charset);
+
+    // The connection is using the server's default (this is different across versions)
+    results r;
+    conn->async_execute("SELECT @@GLOBAL.character_set_client, @@character_set_client", r, as_netresult)
+        .validate_no_error();
+    std::string server_default = r.rows().at(0).at(0).as_string();
+    BOOST_TEST(r.rows().at(0).at(1) == field_view(server_default));
+
+    // Alter session state and the character set
+    conn->async_execute("SET @myvar = 'abc'", r, as_netresult).validate_no_error();
+    conn->async_set_character_set(ascii_charset, as_netresult).validate_no_error();
+
+    // Return the connection
+    conn = pooled_connection();
+
+    // Get the same connection again
+    conn = pool.async_get_connection(diag, as_netresult).get();
+    BOOST_TEST_REQUIRE(conn.valid());
+
+    // The same connection is returned, but session state has been cleared
+    // and the character set returned to the server's default
+    conn->async_execute("SELECT @myvar, @@character_set_client", r, as_netresult).validate_no_error();
+    BOOST_TEST(r.rows() == makerows(2, nullptr, server_default), per_element());
+    BOOST_TEST(conn->current_character_set() == greek_charset);
+
+    // Cleanup the pool
+    pool.cancel();
+    std::move(run_result).validate_no_error_nodiag();
+}
 
 // Spotcheck: constructing a connection_pool with invalid params throws
 BOOST_AUTO_TEST_CASE(invalid_params)

--- a/test/integration/test/snippets/connection_pool.cpp
+++ b/test/integration/test/snippets/connection_pool.cpp
@@ -5,6 +5,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#include <boost/mysql/character_set.hpp>
 #include <boost/mysql/connection_pool.hpp>
 #include <boost/mysql/diagnostics.hpp>
 #include <boost/mysql/error_code.hpp>
@@ -130,15 +131,17 @@ public:
     {
         // This function will run within the strand. Binding the passed callback to
         // the strand will make async_get_connection run it within the strand, too.
-        pool_.async_get_connection(asio::cancel_after(
-            std::chrono::seconds(30),
-            asio::bind_executor(
-                strand_,
-                [self = shared_from_this()](boost::system::error_code, mysql::pooled_connection) {
-                    // Use the connection as required
-                }
+        pool_.async_get_connection(
+            asio::cancel_after(
+                std::chrono::seconds(30),
+                asio::bind_executor(
+                    strand_,
+                    [self = shared_from_this()](boost::system::error_code, mysql::pooled_connection) {
+                        // Use the connection as required
+                    }
+                )
             )
-        ));
+        );
     }
 };
 
@@ -215,6 +218,17 @@ BOOST_AUTO_TEST_CASE(section_connection_pool)
             pool.cancel();
         });
 #endif
+    }
+    {
+        //[connection_pool_charset_strategy
+        mysql::pool_params params;
+
+        // Connections will no longer issue SET NAMES statements when reset.
+        // Instead, they rely on the server's default character set being the one
+        // passed here. You must verify yourself that the server's default matches
+        // what you pass! Use this as an optimization, and only if you know what you are doing.
+        params.charset_strategy = mysql::pool_charset_strategy::use_server_default(mysql::utf8mb4_charset);
+        //]
     }
     {
         //[connection_pool_thread_safe_create

--- a/test/unit/include/test_unit/algo_test.hpp
+++ b/test/unit/include/test_unit/algo_test.hpp
@@ -86,6 +86,7 @@ class BOOST_ATTRIBUTE_NODISCARD algo_test
         boost::optional<bool> tls_active;
         boost::optional<bool> backslash_escapes;
         boost::optional<character_set> current_charset;
+        boost::optional<character_set> server_default_charset;
     } state_changes_;
 
     class state_checker;
@@ -204,6 +205,13 @@ public:
     algo_test& will_set_current_charset(character_set expected)
     {
         state_changes_.current_charset = expected;
+        return *this;
+    }
+
+    BOOST_ATTRIBUTE_NODISCARD
+    algo_test& will_set_server_default_charset(character_set expected)
+    {
+        state_changes_.server_default_charset = expected;
         return *this;
     }
 

--- a/test/unit/include/test_unit/printing.hpp
+++ b/test/unit/include/test_unit/printing.hpp
@@ -18,6 +18,10 @@ namespace mysql {
 enum class address_type;
 std::ostream& operator<<(std::ostream& os, address_type value);
 
+// pool_charset_strategy_type
+enum class pool_charset_strategy_type;
+std::ostream& operator<<(std::ostream& os, pool_charset_strategy_type value);
+
 namespace detail {
 
 // capabilities

--- a/test/unit/src/utils.cpp
+++ b/test/unit/src/utils.cpp
@@ -13,6 +13,7 @@
 #include <boost/mysql/error_code.hpp>
 #include <boost/mysql/error_with_diagnostics.hpp>
 #include <boost/mysql/metadata_mode.hpp>
+#include <boost/mysql/pool_params.hpp>
 
 #include <boost/mysql/detail/access.hpp>
 #include <boost/mysql/detail/coldef_view.hpp>
@@ -168,9 +169,7 @@ public:
           expected_tls_active(changes.tls_active.value_or(st.tls_active)),
           expected_backslash_escapes(changes.backslash_escapes.value_or(st.backslash_escapes)),
           expected_charset(changes.current_charset.value_or(st.current_charset)),
-          expected_server_default_charset(
-              changes.server_default_charset.value_or(st.server_default_charset)
-          )
+          expected_server_default_charset(changes.server_default_charset.value_or(st.server_default_charset))
     {
     }
 
@@ -619,6 +618,23 @@ static const char* to_string(address_type v)
 
 std::ostream& boost::mysql::operator<<(std::ostream& os, address_type v) { return os << ::to_string(v); }
 
+// pool_charset_strategy_type
+static const char* to_string(pool_charset_strategy_type v)
+{
+    switch (v)
+    {
+    case pool_charset_strategy_type::set_to_utf8mb4: return "pool_charset_strategy_type::set_to_utf8mb4";
+    case pool_charset_strategy_type::use_server_default:
+        return "pool_charset_strategy_type::use_server_default";
+    default: return "<unknown pool_charset_strategy_type>";
+    }
+}
+
+std::ostream& boost::mysql::operator<<(std::ostream& os, pool_charset_strategy_type v)
+{
+    return os << ::to_string(v);
+}
+
 // capabilities
 std::ostream& boost::mysql::detail::operator<<(std::ostream& os, capabilities v)
 {
@@ -813,12 +829,14 @@ boost::mysql::any_connection boost::mysql::test::create_test_any_connection(
     detail::connection_status initial_status
 )
 {
-    auto res = any_connection(detail::access::construct<any_connection>(
-        std::unique_ptr<detail::engine>(
-            new detail::engine_impl<detail::engine_stream_adaptor<test_stream>>(ctx.get_executor())
-        ),
-        params
-    ));
+    auto res = any_connection(
+        detail::access::construct<any_connection>(
+            std::unique_ptr<detail::engine>(
+                new detail::engine_impl<detail::engine_stream_adaptor<test_stream>>(ctx.get_executor())
+            ),
+            params
+        )
+    );
     detail::access::get_impl(res).get_state().data().status = initial_status;
     return res;
 }

--- a/test/unit/src/utils.cpp
+++ b/test/unit/src/utils.cpp
@@ -154,6 +154,7 @@ class boost::mysql::test::algo_test::state_checker
     bool expected_tls_active;
     bool expected_backslash_escapes;
     character_set expected_charset;
+    character_set expected_server_default_charset;
 
 public:
     state_checker(detail::connection_state_data& st, const expected_state_changes_t& changes) noexcept
@@ -166,7 +167,10 @@ public:
           expected_tls_supported(changes.tls_active.value_or(st.tls_supported)),
           expected_tls_active(changes.tls_active.value_or(st.tls_active)),
           expected_backslash_escapes(changes.backslash_escapes.value_or(st.backslash_escapes)),
-          expected_charset(changes.current_charset.value_or(st.current_charset))
+          expected_charset(changes.current_charset.value_or(st.current_charset)),
+          expected_server_default_charset(
+              changes.server_default_charset.value_or(st.server_default_charset)
+          )
     {
     }
 
@@ -181,6 +185,7 @@ public:
         BOOST_TEST(st_.tls_active == expected_tls_active);
         BOOST_TEST(st_.backslash_escapes == expected_backslash_escapes);
         BOOST_TEST(st_.current_charset == expected_charset);
+        BOOST_TEST(st_.server_default_charset == expected_server_default_charset);
         BOOST_TEST(!st_.op_in_progress);  // No algorithm should modify this
     }
 };

--- a/test/unit/test/connection_pool.cpp
+++ b/test/unit/test/connection_pool.cpp
@@ -50,8 +50,7 @@ struct pooled_connection_fixture
             pool->params(),
             ctx.get_executor(),
             ctx.get_executor(),
-            pool->shared_state(),
-            &pool->reset_pipeline_request()
+            pool->shared_state()
         )};
     }
 

--- a/test/unit/test/pool_params.cpp
+++ b/test/unit/test/pool_params.cpp
@@ -17,6 +17,9 @@
 #include <chrono>
 #include <stdexcept>
 
+#include "test_common/printing.hpp"
+#include "test_unit/printing.hpp"
+
 using namespace boost::mysql;
 namespace asio = boost::asio;
 
@@ -161,6 +164,24 @@ BOOST_AUTO_TEST_CASE(valid_params)
             BOOST_CHECK_NO_THROW(detail::check_validity(params));
         }
     }
+}
+
+//
+// pool_charset_strategy
+//
+
+BOOST_AUTO_TEST_CASE(charset_strategy_accessors)
+{
+    // Default-constructed: equivalent to set_to_utf8mb4
+    BOOST_TEST(pool_charset_strategy().type() == pool_charset_strategy_type::set_to_utf8mb4);
+
+    // set_to_utf8mb4
+    BOOST_TEST(pool_charset_strategy::set_to_utf8mb4().type() == pool_charset_strategy_type::set_to_utf8mb4);
+
+    // use_server_default stores the type and the passed charset
+    auto strategy = pool_charset_strategy::use_server_default(ascii_charset);
+    BOOST_TEST(strategy.type() == pool_charset_strategy_type::use_server_default);
+    BOOST_TEST(strategy.server_default_charset() == ascii_charset);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/test/sansio/handshake/handshake_common.hpp
+++ b/test/unit/test/sansio/handshake/handshake_common.hpp
@@ -104,7 +104,8 @@ public:
                     int1{25},  // character set
                     int2{0},   // status flags
                     caps_high,
-                    int1{static_cast<std::uint8_t>(auth_plugin_data_.size() + 1u)
+                    int1{
+                        static_cast<std::uint8_t>(auth_plugin_data_.size() + 1u)
                     },                  // auth plugin data length
                     string_fixed<10>{}  // reserved
                 );
@@ -174,15 +175,17 @@ public:
     std::vector<std::uint8_t> build() const
     {
         auto body = serialize_to_vector([this](detail::serialization_context& ctx) {
-            ctx.serialize(detail::login_request{
-                caps_,
-                detail::max_packet_size,
-                collation_id_,
-                username_,
-                auth_response_,
-                database_,
-                auth_plugin_name_
-            });
+            ctx.serialize(
+                detail::login_request{
+                    caps_,
+                    detail::max_packet_size,
+                    collation_id_,
+                    username_,
+                    auth_response_,
+                    database_,
+                    auth_plugin_name_
+                }
+            );
         });
         return create_frame(seqnum_, body);
     }
@@ -264,7 +267,7 @@ struct handshake_fixture : algo_fixture_base
         const handshake_params& hparams = handshake_params("example_user", password),
         bool secure_transport = false
     )
-        : algo({hparams, secure_transport})
+        : algo({hparams, secure_transport, {}})
     {
         st.status = detail::connection_status::not_connected;
     }

--- a/test/unit/test/sansio/handshake/handshake_common.hpp
+++ b/test/unit/test/sansio/handshake/handshake_common.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_MYSQL_TEST_UNIT_TEST_SANSIO_HANDSHAKE_HANDSHAKE_COMMON_HPP
 #define BOOST_MYSQL_TEST_UNIT_TEST_SANSIO_HANDSHAKE_HANDSHAKE_COMMON_HPP
 
+#include <boost/mysql/character_set.hpp>
 #include <boost/mysql/string_view.hpp>
 
 #include <boost/mysql/impl/internal/protocol/capabilities.hpp>
@@ -265,9 +266,10 @@ struct handshake_fixture : algo_fixture_base
 
     handshake_fixture(
         const handshake_params& hparams = handshake_params("example_user", password),
-        bool secure_transport = false
+        bool secure_transport = false,
+        character_set server_default_charset = {}
     )
-        : algo({hparams, secure_transport, {}})
+        : algo({hparams, secure_transport, server_default_charset})
     {
         st.status = detail::connection_status::not_connected;
     }

--- a/test/unit/test/sansio/handshake/handshake_connection_state_data.cpp
+++ b/test/unit/test/sansio/handshake/handshake_connection_state_data.cpp
@@ -5,6 +5,8 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#include <boost/mysql/defaults.hpp>
+
 #include "handshake_common.hpp"
 #include "test_unit/create_ok.hpp"
 #include "test_unit/create_ok_frame.hpp"
@@ -106,12 +108,153 @@ BOOST_AUTO_TEST_CASE(unknown_collation)
         .check(fix);
 }
 
-// server_default_charset set if passed as parameter
-// server_default_charset reset if it was previously set
-// known collation with non-empty server_default_charset => uses known collation
-// unknown collation with non-empty server_default_charset => sets current charset to invalid
-// invalid_collation_id with non-empty server_default_charset
-// invalid_collation_id with empty server_default_charset
+//
+// server_default_charset
+//
+
+// A sentinel character set representing the server's default. It uses a name
+// that no collation ID maps to, so we can tell it apart from the charset that
+// the connection collation would resolve to.
+const character_set server_default_cs{"server_default", detail::next_char_utf8mb4};
+
+// If a non-empty server_default_charset is passed, it is set in the state data
+BOOST_AUTO_TEST_CASE(server_default_charset_set)
+{
+    // Setup
+    handshake_fixture fix(handshake_params("example_user", password), false, server_default_cs);
+    fix.st.server_default_charset = {"other", detail::next_char_utf8mb4};  // make sure that we set the value
+
+    // Run the test
+    algo_test()
+        .expect_read(server_hello_builder().auth_data(mnp_scramble).build())
+        .expect_write(login_request_builder().auth_response(mnp_hash).build())
+        .expect_read(create_ok_frame(2, ok_builder().build()))
+        .will_set_status(connection_status::ready)
+        .will_set_capabilities(min_caps)
+        .will_set_current_charset(utf8mb4_charset)
+        .will_set_server_default_charset(server_default_cs)
+        .will_set_connection_id(42)
+        .check(fix);
+}
+
+// If an empty server_default_charset is passed, it is reset in the state data
+BOOST_AUTO_TEST_CASE(server_default_charset_empty)
+{
+    // Setup: pass an empty server_default_charset
+    handshake_fixture fix(handshake_params("example_user", password), false, character_set{});
+    fix.st.server_default_charset = server_default_cs;  // make sure that we reset the value
+
+    // Run the test
+    algo_test()
+        .expect_read(server_hello_builder().auth_data(mnp_scramble).build())
+        .expect_write(login_request_builder().auth_response(mnp_hash).build())
+        .expect_read(create_ok_frame(2, ok_builder().build()))
+        .will_set_status(connection_status::ready)
+        .will_set_capabilities(min_caps)
+        .will_set_current_charset(utf8mb4_charset)
+        .will_set_server_default_charset(character_set{})
+        .will_set_connection_id(42)
+        .check(fix);
+}
+
+// If a known collation and a non-empty server_default_charset is passed, the known
+// collation charset is used (the server default is not consulted)
+BOOST_AUTO_TEST_CASE(server_default_charset_known_collation)
+{
+    // Setup
+    handshake_params hparams("example_user", password);
+    hparams.set_connection_collation(mysql_collations::ascii_general_ci);
+    handshake_fixture fix(hparams, false, server_default_cs);
+
+    // Run the test
+    algo_test()
+        .expect_read(server_hello_builder().auth_data(mnp_scramble).build())
+        .expect_write(
+            login_request_builder()
+                .collation(mysql_collations::ascii_general_ci)
+                .auth_response(mnp_hash)
+                .build()
+        )
+        .expect_read(create_ok_frame(2, ok_builder().build()))
+        .will_set_status(connection_status::ready)
+        .will_set_capabilities(min_caps)
+        .will_set_current_charset(ascii_charset)
+        .will_set_server_default_charset(server_default_cs)
+        .will_set_connection_id(42)
+        .check(fix);
+}
+
+// If an unknown collation and a non-empty server_default_charset is passed, the current
+// charset is unknown
+BOOST_AUTO_TEST_CASE(server_default_charset_unknown_collation)
+{
+    // Setup
+    handshake_params hparams("example_user", password);
+    hparams.set_connection_collation(mysql_collations::utf8mb4_0900_as_ci);
+    handshake_fixture fix(hparams, false, server_default_cs);
+    fix.st.current_charset = {"other", detail::next_char_utf8mb4};  // make sure that we set the value
+
+    // Run the test
+    algo_test()
+        .expect_read(server_hello_builder().auth_data(mnp_scramble).build())
+        .expect_write(
+            login_request_builder()
+                .collation(mysql_collations::utf8mb4_0900_as_ci)
+                .auth_response(mnp_hash)
+                .build()
+        )
+        .expect_read(create_ok_frame(2, ok_builder().build()))
+        .will_set_status(connection_status::ready)
+        .will_set_capabilities(min_caps)
+        .will_set_current_charset(character_set{})
+        .will_set_server_default_charset(server_default_cs)
+        .will_set_connection_id(42)
+        .check(fix);
+}
+
+// If invalid_connection_id and a non-empty server_default_charset is passed,
+// the current charset is the server default
+BOOST_AUTO_TEST_CASE(server_default_charset_invalid_collation)
+{
+    // Setup
+    handshake_params hparams("example_user", password);
+    hparams.set_connection_collation(invalid_collation_id);
+    handshake_fixture fix(hparams, false, server_default_cs);
+
+    // Run the test
+    algo_test()
+        .expect_read(server_hello_builder().auth_data(mnp_scramble).build())
+        .expect_write(login_request_builder().collation(0).auth_response(mnp_hash).build())
+        .expect_read(create_ok_frame(2, ok_builder().build()))
+        .will_set_status(connection_status::ready)
+        .will_set_capabilities(min_caps)
+        .will_set_current_charset(server_default_cs)
+        .will_set_server_default_charset(server_default_cs)
+        .will_set_connection_id(42)
+        .check(fix);
+}
+
+// If invalid_collation_id and an empty server_default_charset is passed,
+// the current charset is unknown
+BOOST_AUTO_TEST_CASE(server_default_charset_invalid_collation_empty)
+{
+    // Setup
+    handshake_params hparams("example_user", password);
+    hparams.set_connection_collation(invalid_collation_id);
+    handshake_fixture fix(hparams, false, character_set{});
+    fix.st.current_charset = {"other", detail::next_char_utf8mb4};  // make sure that we set the value
+
+    // Run the test
+    algo_test()
+        .expect_read(server_hello_builder().auth_data(mnp_scramble).build())
+        .expect_write(login_request_builder().collation(0).auth_response(mnp_hash).build())
+        .expect_read(create_ok_frame(2, ok_builder().build()))
+        .will_set_status(connection_status::ready)
+        .will_set_capabilities(min_caps)
+        .will_set_current_charset(character_set{})
+        .will_set_connection_id(42)
+        .check(fix);
+}
 
 // The value of backslash_escapes in the final OK packet doesn't get ignored
 BOOST_AUTO_TEST_CASE(backslash_escapes)

--- a/test/unit/test/sansio/handshake/handshake_connection_state_data.cpp
+++ b/test/unit/test/sansio/handshake/handshake_connection_state_data.cpp
@@ -92,10 +92,12 @@ BOOST_AUTO_TEST_CASE(unknown_collation)
     // Run the test
     algo_test()
         .expect_read(server_hello_builder().auth_data(mnp_scramble).build())
-        .expect_write(login_request_builder()
-                          .collation(mysql_collations::utf8mb4_0900_as_ci)
-                          .auth_response(mnp_hash)
-                          .build())
+        .expect_write(
+            login_request_builder()
+                .collation(mysql_collations::utf8mb4_0900_as_ci)
+                .auth_response(mnp_hash)
+                .build()
+        )
         .expect_read(create_ok_frame(2, ok_builder().build()))
         .will_set_status(connection_status::ready)
         .will_set_capabilities(min_caps)
@@ -103,6 +105,13 @@ BOOST_AUTO_TEST_CASE(unknown_collation)
         .will_set_connection_id(42)
         .check(fix);
 }
+
+// server_default_charset set if passed as parameter
+// server_default_charset reset if it was previously set
+// known collation with non-empty server_default_charset => uses known collation
+// unknown collation with non-empty server_default_charset => sets current charset to invalid
+// invalid_collation_id with non-empty server_default_charset
+// invalid_collation_id with empty server_default_charset
 
 // The value of backslash_escapes in the final OK packet doesn't get ignored
 BOOST_AUTO_TEST_CASE(backslash_escapes)

--- a/test/unit/test/sansio/reset_connection.cpp
+++ b/test/unit/test/sansio/reset_connection.cpp
@@ -64,6 +64,21 @@ BOOST_AUTO_TEST_CASE(read_response_success_no_backslash_escapes)
         .check(fix);
 }
 
+BOOST_AUTO_TEST_CASE(read_response_success_nonempty_server_default_charset)
+{
+    // Setup
+    read_response_fixture fix;
+    fix.st.current_charset = utf8mb4_charset;
+    fix.st.server_default_charset = ascii_charset;
+
+    // Run the algo
+    algo_test()
+        .expect_read(create_ok_frame(11, ok_builder().no_backslash_escapes(true).build()))
+        .will_set_backslash_escapes(false)        // OK packet processed
+        .will_set_current_charset(ascii_charset)  // charset was set to the default passed by the user
+        .check(fix);
+}
+
 BOOST_AUTO_TEST_CASE(read_response_error_network)
 {
     algo_test()
@@ -79,11 +94,13 @@ BOOST_AUTO_TEST_CASE(read_response_error_packet)
 
     // Run the algo. The character set is not updated.
     algo_test()
-        .expect_read(err_builder()
-                         .seqnum(11)
-                         .code(common_server_errc::er_bad_db_error)
-                         .message("my_message")
-                         .build_frame())
+        .expect_read(
+            err_builder()
+                .seqnum(11)
+                .code(common_server_errc::er_bad_db_error)
+                .message("my_message")
+                .build_frame()
+        )
         .check(fix, common_server_errc::er_bad_db_error, create_server_diag("my_message"));
 }
 
@@ -128,11 +145,13 @@ BOOST_AUTO_TEST_CASE(reset_conn_error_response)
     // Run the algo. The current charset was not updated
     algo_test()
         .expect_write(create_frame(0, {0x1f}))
-        .expect_read(err_builder()
-                         .seqnum(1)
-                         .code(common_server_errc::er_bad_db_error)
-                         .message("my_message")
-                         .build_frame())
+        .expect_read(
+            err_builder()
+                .seqnum(1)
+                .code(common_server_errc::er_bad_db_error)
+                .message("my_message")
+                .build_frame()
+        )
         .check(fix, common_server_errc::er_bad_db_error, create_server_diag("my_message"));
 }
 

--- a/tools/scripts/build_unix_local.sh
+++ b/tools/scripts/build_unix_local.sh
@@ -10,32 +10,22 @@ set -e
 
 repo_base=$(realpath $(dirname $(realpath $0))/../..)
 
-BK=cmake
-IMAGE=build-gcc13
+BK=docs
+IMAGE=build-docs
 IMAGE_VERSION=1
 CONTAINER=builder-$IMAGE
 FULL_IMAGE=ghcr.io/anarthal/cpp-ci-containers/$IMAGE:$IMAGE_VERSION
-DB=mysql-9_4_0
-DB_VERSION=1
 
-docker start $DB || docker run -d \
-    --name $DB \
-    -v /var/run/mysqld:/var/run/mysqld \
-    -p 3306:3306 \
-    ghcr.io/anarthal/cpp-ci-containers/$DB:$DB_VERSION
 docker start $CONTAINER || docker run -dit \
     --name $CONTAINER \
+    --network host \
     -v "$repo_base:/opt/boost-mysql" \
     -v /var/run/mysqld:/var/run/mysqld \
     $FULL_IMAGE
-docker network connect my-net $DB || echo "DB already connected"
-docker network connect my-net $CONTAINER || echo "Network already connected"
 
 # Command line
-db_args="--server-host=$DB"
 case $BK in
-    b2) cmd="$db_args
-            --toolset=clang
+    b2) cmd="--toolset=clang
             --cxxstd=11
             --variant=release
             --stdlib=native
@@ -48,7 +38,7 @@ case $BK in
             --valgrind=0"
         ;;
     
-    cmake) cmd="$db_args
+    cmake) cmd="
             --cmake-build-type=Debug
             --build-shared-libs=1
             --cxxstd=11
@@ -56,9 +46,7 @@ case $BK in
             "
         ;;
     
-    fuzz) cmd="$db_args" ;;
-
-    bench) cmd="$db_args
+    bench) cmd="
                 --protocol-iters=10
                 --connection-pool-iters=0
                 "


### PR DESCRIPTION
Adds a way to configure which character set is the server using by default, to make tracking more intelligent. This can be used to avoid redundant SET NAMES statements, specially when using connection_pool.

Adds pool_params::charset_strategy and pool_charset_strategy
Adds connect_params::server_default_charset
Adds the invalid_connection_id constant

close #498 