### PR TITLE
Refactor next_power_of_two

### DIFF
--- a/include/boost/mysql/impl/internal/next_power_of_two.hpp
+++ b/include/boost/mysql/impl/internal/next_power_of_two.hpp
@@ -8,7 +8,6 @@
 #ifndef BOOST_MYSQL_IMPL_INTERNAL_NEXT_POWER_OF_TWO_HPP
 #define BOOST_MYSQL_IMPL_INTERNAL_NEXT_POWER_OF_TWO_HPP
 
-#include <boost/assert.hpp>
 #include <boost/core/bit.hpp>
 
 #include <limits>
@@ -18,16 +17,14 @@ namespace mysql {
 namespace detail {
 
 // Returns the smallest power of two greater than or equal to n.
-// Precondition: n must not exceed the largest power of two that fits
-// in std::size_t: n <= 9223372036854775808 (2^63)
-//
-// Passing a larger value results in undefined behavior (overflow).
-// In debug builds, this is caught by BOOST_ASSERT.
+// If n exceeds the largest power of two that fits in std::size_t, then
+// std::numeric_limits<std::size_t>::max() is returned.
 inline std::size_t next_power_of_two(std::size_t n) noexcept
 {
-    // Assert overflow (if value is bigger than maximum power)
-    BOOST_ASSERT(!(n > (std::numeric_limits<std::size_t>::max() >> 1) + 1));
     if (n < 2) return 1;
+
+    if (n > (std::numeric_limits<std::size_t>::max() >> 1) + 1)
+        return std::numeric_limits<std::size_t>::max();
 
     return std::size_t(1) << boost::core::bit_width(n - 1);
 }

--- a/include/boost/mysql/impl/internal/next_power_of_two.hpp
+++ b/include/boost/mysql/impl/internal/next_power_of_two.hpp
@@ -9,56 +9,27 @@
 #define BOOST_MYSQL_IMPL_INTERNAL_NEXT_POWER_OF_TWO_HPP
 
 #include <boost/assert.hpp>
+#include <boost/core/bit.hpp>
 
-#include <type_traits>
 #include <limits>
 
 namespace boost {
 namespace mysql {
 namespace detail {
 
-template<int Shift, class UnsignedInt, bool Continue>
-struct recursive_shift_or;
-
-// Apply shift and continue to the next power of 2
-template<int Shift, class UnsignedInt>
-struct recursive_shift_or<Shift, UnsignedInt, true>
-{
-    static void apply(UnsignedInt& n)
-    {
-        n |= n >> Shift;
-        recursive_shift_or<Shift * 2, UnsignedInt, (Shift * 2 < sizeof(UnsignedInt) * 8)>::apply(n);
-    }
-};
-
-// Stop recursion when shift exceeds type width
-template<int Shift, class UnsignedInt>
-struct recursive_shift_or<Shift, UnsignedInt, false>
-{
-    static void apply(UnsignedInt&) {}
-};
-
 // Returns the smallest power of two greater than or equal to n.
 // Precondition: n must not exceed the largest power of two that fits
-// in UnsignedInt. For example:
-//   - uint8_t:  n <= 128 (2^7)
-//   - uint16_t: n <= 32768 (2^15)
-//   - uint32_t: n <= 2147483648 (2^31)
-//   - uint64_t: n <= 9223372036854775808 (2^63)
+// in std::size_t: n <= 9223372036854775808 (2^63)
 //
 // Passing a larger value results in undefined behavior (overflow).
 // In debug builds, this is caught by BOOST_ASSERT.
-template<class UnsignedInt>
-UnsignedInt next_power_of_two(UnsignedInt n) noexcept
+inline std::size_t next_power_of_two(std::size_t n) noexcept
 {
-    static_assert(std::is_unsigned<UnsignedInt>::value, "");
     // Assert overflow (if value is bigger than maximum power)
-    BOOST_ASSERT(!(n > (std::numeric_limits<UnsignedInt>::max() >> 1) + 1));
-    if (n == 0) return 1;
-    n--;
-    // Fill all lower bits
-    recursive_shift_or<1, UnsignedInt, (1 < sizeof(UnsignedInt) * 8)>::apply(n);
-    return n + 1;
+    BOOST_ASSERT(!(n > (std::numeric_limits<std::size_t>::max() >> 1) + 1));
+    if (n < 2) return 1;
+
+    return std::size_t(1) << boost::core::bit_width(n - 1);
 }
 
 }  // namespace detail

--- a/include/boost/mysql/impl/internal/next_power_of_two.hpp
+++ b/include/boost/mysql/impl/internal/next_power_of_two.hpp
@@ -23,10 +23,10 @@ inline std::size_t next_power_of_two(std::size_t n) noexcept
 {
     if (n < 2) return 1;
 
-    if (n > (std::numeric_limits<std::size_t>::max() >> 1) + 1)
-        return std::numeric_limits<std::size_t>::max();
+    if (n > ((std::numeric_limits<std::size_t>::max)() >> 1) + 1)
+        return (std::numeric_limits<std::size_t>::max)();
 
-    return std::size_t(1) << boost::core::bit_width(n - 1);
+    return static_cast<std::size_t>(1u) << boost::core::bit_width(n - 1);
 }
 
 }  // namespace detail

--- a/include/boost/mysql/impl/internal/sansio/read_buffer.hpp
+++ b/include/boost/mysql/impl/internal/sansio/read_buffer.hpp
@@ -147,7 +147,7 @@ public:
         if (free_size() < n)
         {
             std::size_t required_size = buffer_.size() + n - free_size();
-            std::size_t new_size = next_power_of_two<std::size_t>(required_size);
+            std::size_t new_size = next_power_of_two(required_size);
             if (new_size > max_size_)
             {
                 new_size = required_size;

--- a/test/unit/test/impl/next_power_of_two.cpp
+++ b/test/unit/test/impl/next_power_of_two.cpp
@@ -20,6 +20,14 @@ BOOST_AUTO_TEST_CASE(basic)
     // n = 0 (special case)
     BOOST_TEST(next_power_of_two(0u) == 1u);
 
+    // n is bigger than largest power of two (special case)
+    BOOST_TEST(next_power_of_two((std::numeric_limits<std::size_t>::max() >> 1) + 2) == std::numeric_limits<std::size_t>::max());
+    BOOST_TEST(next_power_of_two((std::numeric_limits<std::size_t>::max() >> 1) + 1024) == std::numeric_limits<std::size_t>::max());
+    BOOST_TEST(next_power_of_two((std::numeric_limits<std::size_t>::max() >> 1) + 888) == std::numeric_limits<std::size_t>::max());
+
+    // n is largest power of two (corner case)
+    BOOST_TEST(next_power_of_two((std::numeric_limits<std::size_t>::max() >> 1) + 1 == std::numeric_limits<std::size_t>::max() >> 1) + 1);
+
     // n is already power of two
     BOOST_TEST(next_power_of_two(1u) == 1u);
     BOOST_TEST(next_power_of_two(2u) == 2u);
@@ -29,6 +37,7 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_TEST(next_power_of_two(32u) == 32u);
     BOOST_TEST(next_power_of_two(64u) == 64u);
     BOOST_TEST(next_power_of_two(128u) == 128u);
+    BOOST_TEST(next_power_of_two(2048u) == 2048u);
 
     // n just below power of two
     BOOST_TEST(next_power_of_two(3u) == 4u);
@@ -37,6 +46,7 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_TEST(next_power_of_two(31u) == 32u);
     BOOST_TEST(next_power_of_two(63u) == 64u);
     BOOST_TEST(next_power_of_two(127u) == 128u);
+    BOOST_TEST(next_power_of_two(2047u) == 2048u);
 
     // n just above power of two
     BOOST_TEST(next_power_of_two(5u) == 8u);
@@ -45,6 +55,7 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_TEST(next_power_of_two(33u) == 64u);
     BOOST_TEST(next_power_of_two(65u) == 128u);
     BOOST_TEST(next_power_of_two(129u) == 256u);
+    BOOST_TEST(next_power_of_two(2049u) == 4096u);
 
     // n is random value
     BOOST_TEST(next_power_of_two(6u) == 8u);
@@ -57,6 +68,7 @@ BOOST_AUTO_TEST_CASE(basic)
     BOOST_TEST(next_power_of_two(400u) == 512u);
     BOOST_TEST(next_power_of_two(505u) == 512u);
     BOOST_TEST(next_power_of_two(888u) == 1024u);
+    BOOST_TEST(next_power_of_two(2222u) == 4096u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/test/impl/next_power_of_two.cpp
+++ b/test/unit/test/impl/next_power_of_two.cpp
@@ -18,73 +18,45 @@ BOOST_AUTO_TEST_SUITE(test_next_power_of_two)
 BOOST_AUTO_TEST_CASE(basic)
 {
     // n = 0 (special case)
-    BOOST_TEST(next_power_of_two<std::size_t>(0u) == 1u);
-    
+    BOOST_TEST(next_power_of_two(0u) == 1u);
+
     // n is already power of two
-    BOOST_TEST(next_power_of_two<std::size_t>(1u) == 1u);
-    BOOST_TEST(next_power_of_two<std::size_t>(2u) == 2u);
-    BOOST_TEST(next_power_of_two<std::size_t>(4u) == 4u);
-    BOOST_TEST(next_power_of_two<std::size_t>(8u) == 8u);
-    BOOST_TEST(next_power_of_two<std::size_t>(16u) == 16u);
-    BOOST_TEST(next_power_of_two<std::size_t>(32u) == 32u);
-    BOOST_TEST(next_power_of_two<std::size_t>(64u) == 64u);
-    BOOST_TEST(next_power_of_two<std::size_t>(128u) == 128u);
-    
+    BOOST_TEST(next_power_of_two(1u) == 1u);
+    BOOST_TEST(next_power_of_two(2u) == 2u);
+    BOOST_TEST(next_power_of_two(4u) == 4u);
+    BOOST_TEST(next_power_of_two(8u) == 8u);
+    BOOST_TEST(next_power_of_two(16u) == 16u);
+    BOOST_TEST(next_power_of_two(32u) == 32u);
+    BOOST_TEST(next_power_of_two(64u) == 64u);
+    BOOST_TEST(next_power_of_two(128u) == 128u);
+
     // n just below power of two
-    BOOST_TEST(next_power_of_two<std::size_t>(3u) == 4u);
-    BOOST_TEST(next_power_of_two<std::size_t>(7u) == 8u);
-    BOOST_TEST(next_power_of_two<std::size_t>(15u) == 16u);
-    BOOST_TEST(next_power_of_two<std::size_t>(31u) == 32u);
-    BOOST_TEST(next_power_of_two<std::size_t>(63u) == 64u);
-    BOOST_TEST(next_power_of_two<std::size_t>(127u) == 128u);
-    
+    BOOST_TEST(next_power_of_two(3u) == 4u);
+    BOOST_TEST(next_power_of_two(7u) == 8u);
+    BOOST_TEST(next_power_of_two(15u) == 16u);
+    BOOST_TEST(next_power_of_two(31u) == 32u);
+    BOOST_TEST(next_power_of_two(63u) == 64u);
+    BOOST_TEST(next_power_of_two(127u) == 128u);
+
     // n just above power of two
-    BOOST_TEST(next_power_of_two<std::size_t>(5u) == 8u);
-    BOOST_TEST(next_power_of_two<std::size_t>(9u) == 16u);
-    BOOST_TEST(next_power_of_two<std::size_t>(17u) == 32u);
-    BOOST_TEST(next_power_of_two<std::size_t>(33u) == 64u);
-    BOOST_TEST(next_power_of_two<std::size_t>(65u) == 128u);
-    BOOST_TEST(next_power_of_two<std::size_t>(129u) == 256u);
+    BOOST_TEST(next_power_of_two(5u) == 8u);
+    BOOST_TEST(next_power_of_two(9u) == 16u);
+    BOOST_TEST(next_power_of_two(17u) == 32u);
+    BOOST_TEST(next_power_of_two(33u) == 64u);
+    BOOST_TEST(next_power_of_two(65u) == 128u);
+    BOOST_TEST(next_power_of_two(129u) == 256u);
 
     // n is random value
-    BOOST_TEST(next_power_of_two<std::size_t>(6u) == 8u);
-    BOOST_TEST(next_power_of_two<std::size_t>(13u) == 16u);
-    BOOST_TEST(next_power_of_two<std::size_t>(21u) == 32u);
-    BOOST_TEST(next_power_of_two<std::size_t>(45u) == 64u);
-    BOOST_TEST(next_power_of_two<std::size_t>(89u) == 128u);
-    BOOST_TEST(next_power_of_two<std::size_t>(200u) == 256u);
-    BOOST_TEST(next_power_of_two<std::size_t>(300u) == 512u);
-    BOOST_TEST(next_power_of_two<std::size_t>(400u) == 512u);
-    BOOST_TEST(next_power_of_two<std::size_t>(505u) == 512u);
-    BOOST_TEST(next_power_of_two<std::size_t>(888u) == 1024u);
-}
-
-BOOST_AUTO_TEST_CASE(different_types)
-{
-    // uint8_t
-    BOOST_TEST(next_power_of_two<std::uint8_t>(0u) == 1u);
-    BOOST_TEST(next_power_of_two<std::uint8_t>(62u) == 64u);
-    BOOST_TEST(next_power_of_two<std::uint8_t>(100u) == 128u);
-    BOOST_TEST(next_power_of_two<std::uint8_t>(128u) == 128u);
-    
-    // uint16_t
-    BOOST_TEST(next_power_of_two<std::uint16_t>(0u) == 1u);
-    BOOST_TEST(next_power_of_two<std::uint16_t>(1000u) == 1024u);
-    BOOST_TEST(next_power_of_two<std::uint16_t>(16383u) == 16384u);
-    BOOST_TEST(next_power_of_two<std::uint16_t>(32768u) == 32768u);
-    
-    // uint32_t
-    BOOST_TEST(next_power_of_two<std::uint32_t>(0u) == 1u);
-    BOOST_TEST(next_power_of_two<std::uint32_t>(100000u) == 131072u);
-    BOOST_TEST(next_power_of_two<std::uint32_t>(1u << 30) == 1u << 30);
-    BOOST_TEST(next_power_of_two<std::uint32_t>((1u << 30) + 1) == 1u << 31);
-    
-    // uint64_t
-    BOOST_TEST(next_power_of_two<std::uint64_t>(0u) == 1u);
-    BOOST_TEST(next_power_of_two<std::uint64_t>(1ull << 40) == 1ull << 40);
-    BOOST_TEST(next_power_of_two<std::uint64_t>((1ull << 40) + 1) == 1ull << 41);
-    BOOST_TEST(next_power_of_two<std::uint64_t>(1ull << 62) == 1ull << 62);
-    BOOST_TEST(next_power_of_two<std::uint64_t>((1ull << 62) + 1) == 1ull << 63);
+    BOOST_TEST(next_power_of_two(6u) == 8u);
+    BOOST_TEST(next_power_of_two(13u) == 16u);
+    BOOST_TEST(next_power_of_two(21u) == 32u);
+    BOOST_TEST(next_power_of_two(45u) == 64u);
+    BOOST_TEST(next_power_of_two(89u) == 128u);
+    BOOST_TEST(next_power_of_two(200u) == 256u);
+    BOOST_TEST(next_power_of_two(300u) == 512u);
+    BOOST_TEST(next_power_of_two(400u) == 512u);
+    BOOST_TEST(next_power_of_two(505u) == 512u);
+    BOOST_TEST(next_power_of_two(888u) == 1024u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Faster and cleaner implementation. It's branchless too, but even more optimized than my previous solution:
https://godbolt.org/z/b1G48vY9W

Same approach used by Boost.Unordered:
https://github.com/boostorg/unordered/blob/636164f1357cf217374313820a457c31b50fcfc7/include/boost/unordered/detail/foa/core.hpp#L829-L851

Additionally, I have restricted this function to size_t, as there is no need to support other unsigned types.