### PR TITLE
Add standalone headers tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,3 +50,6 @@ add_subdirectory(unit)
 if(BOOST_MYSQL_INTEGRATION_TESTS)
     add_subdirectory(integration)
 endif()
+
+# Standalone headers testing
+add_subdirectory(standalone)

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -165,3 +165,5 @@ alias launch_with_valgrind
     ;
 
 build-project unit ;
+
+build-project standalone ;

--- a/test/standalone/CMakeLists.txt
+++ b/test/standalone/CMakeLists.txt
@@ -87,7 +87,7 @@ target_include_directories(
 
 target_link_libraries(
     boost_mysql_standalone_tests
-    INTERFACE
+    PRIVATE
     Boost::asio
     Boost::assert
     Boost::charconv

--- a/test/standalone/CMakeLists.txt
+++ b/test/standalone/CMakeLists.txt
@@ -1,0 +1,82 @@
+#
+# Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+add_library(
+    boost_mysql_standalone_tests
+    OBJECT
+
+    any_address.cpp
+    any_connection.cpp
+    bad_field_access.cpp
+    blob_view.cpp
+    blob.cpp
+    buffer_params.cpp
+    character_set.cpp
+    client_errc.cpp
+    column_type.cpp
+    common_server_errc.cpp
+    connect_params.cpp
+    connection_pool.cpp
+    connection.cpp
+    constant_string_view.cpp
+    date.cpp
+    datetime.cpp
+    days.cpp
+    defaults.cpp
+    diagnostics.cpp
+    error_categories.cpp
+    error_code.cpp
+    error_with_diagnostics.cpp
+    escape_string.cpp
+    execution_state.cpp
+    field_kind.cpp
+    field_view.cpp
+    field.cpp
+    format_sql.cpp
+    handshake_params.cpp
+    is_fatal_error.cpp
+    mariadb_collations.cpp
+    mariadb_server_errc.cpp
+    metadata_collection_view.cpp
+    metadata_mode.cpp
+    metadata.cpp
+    mysql_collations.cpp
+    mysql_server_errc.cpp
+    pfr.cpp
+    pipeline.cpp
+    pool_params.cpp
+    results.cpp
+    resultset_view.cpp
+    resultset.cpp
+    row_view.cpp
+    row.cpp
+    rows_view.cpp
+    rows.cpp
+    sequence.cpp
+    ssl_mode.cpp
+    statement.cpp
+    static_execution_state.cpp
+    static_results.cpp
+    string_view.cpp
+    tcp_ssl.cpp
+    tcp.cpp
+    throw_on_error.cpp
+    time.cpp
+    underlying_row.cpp
+    unix_ssl.cpp
+    unix.cpp
+    with_diagnostics.cpp
+    with_params.cpp
+)
+
+target_include_directories(
+    boost_mysql_standalone_tests
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+)
+
+boost_mysql_test_target_settings(boost_mysql_standalone_tests)

--- a/test/standalone/CMakeLists.txt
+++ b/test/standalone/CMakeLists.txt
@@ -100,6 +100,7 @@ target_link_libraries(
     Boost::intrusive
     Boost::mp11
     Boost::optional
+    Boost::pfr
     Boost::system
     Boost::throw_exception
     Boost::variant2

--- a/test/standalone/CMakeLists.txt
+++ b/test/standalone/CMakeLists.txt
@@ -73,13 +73,6 @@ add_library(
     with_params.cpp
 )
 
-target_include_directories(
-    boost_mysql_standalone_tests
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../include
-    ${OPENSSL_INCLUDE_DIR}
-)
-
 target_link_libraries(
     boost_mysql_standalone_tests
     PRIVATE

--- a/test/standalone/CMakeLists.txt
+++ b/test/standalone/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 add_library(
     boost_mysql_standalone_tests
-    OBJECT
+    STATIC
 
     any_address.cpp
     any_connection.cpp

--- a/test/standalone/CMakeLists.txt
+++ b/test/standalone/CMakeLists.txt
@@ -77,33 +77,13 @@ target_include_directories(
     boost_mysql_standalone_tests
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
-)
-
-target_include_directories(
-    boost_mysql_standalone_tests
-    PRIVATE
     ${OPENSSL_INCLUDE_DIR}
 )
 
 target_link_libraries(
     boost_mysql_standalone_tests
     PRIVATE
-    Boost::asio
-    Boost::assert
-    Boost::charconv
-    Boost::compat
-    Boost::config
-    Boost::container
-    Boost::core
-    Boost::describe
-    Boost::endian
-    Boost::intrusive
-    Boost::mp11
-    Boost::optional
-    Boost::pfr
-    Boost::system
-    Boost::throw_exception
-    Boost::variant2
+    Boost::mysql
 )
 
 boost_mysql_test_target_settings(boost_mysql_standalone_tests)

--- a/test/standalone/CMakeLists.txt
+++ b/test/standalone/CMakeLists.txt
@@ -84,6 +84,7 @@ target_link_libraries(
     boost_mysql_standalone_tests
     PRIVATE
     Boost::mysql
+    Boost::pfr
 )
 
 boost_mysql_test_target_settings(boost_mysql_standalone_tests)

--- a/test/standalone/CMakeLists.txt
+++ b/test/standalone/CMakeLists.txt
@@ -79,4 +79,30 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
 )
 
+target_include_directories(
+    boost_mysql_standalone_tests
+    PRIVATE
+    ${OPENSSL_INCLUDE_DIR}
+)
+
+target_link_libraries(
+    boost_mysql_standalone_tests
+    INTERFACE
+    Boost::asio
+    Boost::assert
+    Boost::charconv
+    Boost::compat
+    Boost::config
+    Boost::container
+    Boost::core
+    Boost::describe
+    Boost::endian
+    Boost::intrusive
+    Boost::mp11
+    Boost::optional
+    Boost::system
+    Boost::throw_exception
+    Boost::variant2
+)
+
 boost_mysql_test_target_settings(boost_mysql_standalone_tests)

--- a/test/standalone/Jamfile
+++ b/test/standalone/Jamfile
@@ -41,8 +41,8 @@ project : requirements
     <library>/boost/system//boost_system
     <library>/boost/throw_exception//boost_throw_exception
     <library>/boost/variant2//boost_variant2
-    <library>/openssl//ssl
-    <library>/openssl//crypto
+    [ ac.check-library /openssl//ssl    : <library>/openssl//ssl/<link>shared : <build>no ]
+    [ ac.check-library /openssl//crypto : <library>/openssl//crypto/<link>shared : <build>no ]
     ;
 
 compile any_address.cpp ;

--- a/test/standalone/Jamfile
+++ b/test/standalone/Jamfile
@@ -7,7 +7,11 @@
 
 import testing : compile ;
 
-project : requirements <library>/boost/mysql//boost_mysql ;
+project : requirements
+    <library>/boost/mysql//boost_mysql
+    [ ac.check-library /openssl//ssl    : <library>/openssl//ssl/<link>shared : <build>no ]
+    [ ac.check-library /openssl//crypto : <library>/openssl//crypto/<link>shared : <build>no ]
+    ;
 
 compile any_address.cpp ;
 compile any_connection.cpp ;

--- a/test/standalone/Jamfile
+++ b/test/standalone/Jamfile
@@ -9,9 +9,7 @@ import testing : compile ;
 import ac ;
 
 project : requirements
-    <library>/boost/mysql//boost_mysql
-    [ ac.check-library /openssl//ssl    : <library>/openssl//ssl/<link>shared : <build>no ]
-    [ ac.check-library /openssl//crypto : <library>/openssl//crypto/<link>shared : <build>no ]
+    <library>/boost/mysql/test//boost_mysql
     ;
 
 compile any_address.cpp ;

--- a/test/standalone/Jamfile
+++ b/test/standalone/Jamfile
@@ -1,0 +1,74 @@
+#
+# Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+# import compile rule
+import testing ;
+
+project : requirements <include>../../include ;
+
+compile any_address.cpp ;
+compile any_connection.cpp ;
+compile bad_field_access.cpp ;
+compile blob_view.cpp ;
+compile blob.cpp ;
+compile buffer_params.cpp ;
+compile character_set.cpp ;
+compile client_errc.cpp ;
+compile column_type.cpp ;
+compile common_server_errc.cpp ;
+compile connect_params.cpp ;
+compile connection_pool.cpp ;
+compile connection.cpp ;
+compile constant_string_view.cpp ;
+compile date.cpp ;
+compile datetime.cpp ;
+compile days.cpp ;
+compile defaults.cpp ;
+compile diagnostics.cpp ;
+compile error_categories.cpp ;
+compile error_code.cpp ;
+compile error_with_diagnostics.cpp ;
+compile escape_string.cpp ;
+compile execution_state.cpp ;
+compile field_kind.cpp ;
+compile field_view.cpp ;
+compile field.cpp ;
+compile format_sql.cpp ;
+compile handshake_params.cpp ;
+compile is_fatal_error.cpp ;
+compile mariadb_collations.cpp ;
+compile mariadb_server_errc.cpp ;
+compile metadata_collection_view.cpp ;
+compile metadata_mode.cpp ;
+compile metadata.cpp ;
+compile mysql_collations.cpp ;
+compile mysql_server_errc.cpp ;
+compile pfr.cpp ;
+compile pipeline.cpp ;
+compile pool_params.cpp ;
+compile results.cpp ;
+compile resultset_view.cpp ;
+compile resultset.cpp ;
+compile row_view.cpp ;
+compile row.cpp ;
+compile rows_view.cpp ;
+compile rows.cpp ;
+compile sequence.cpp ;
+compile ssl_mode.cpp ;
+compile statement.cpp ;
+compile static_execution_state.cpp ;
+compile static_results.cpp ;
+compile string_view.cpp ;
+compile tcp_ssl.cpp ;
+compile tcp.cpp ;
+compile throw_on_error.cpp ;
+compile time.cpp ;
+compile underlying_row.cpp ;
+compile unix_ssl.cpp ;
+compile unix.cpp ;
+compile with_diagnostics.cpp ;
+compile with_params.cpp ;

--- a/test/standalone/Jamfile
+++ b/test/standalone/Jamfile
@@ -5,8 +5,24 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-# import compile rule
-import testing ;
+import testing : compile ;
+import ac ;
+import indirect ;
+
+rule do_fail_impl ( a * )
+{
+    exit "OpenSSL could not be found. Don't build target fail_if_no_openssl to skip this check" ;
+}
+
+local do_fail = [ indirect.make do_fail_impl ] ;
+
+alias fail_if_no_openssl
+    : requirements
+        [ ac.check-library /openssl//ssl    : : <conditional>@$(do_fail) ]
+        [ ac.check-library /openssl//crypto : : <conditional>@$(do_fail) ]
+;
+
+explicit fail_if_no_openssl ;
 
 project : requirements
     <include>../../include

--- a/test/standalone/Jamfile
+++ b/test/standalone/Jamfile
@@ -25,7 +25,8 @@ project : requirements
     <library>//boost/system//boost_system
     <library>//boost/throw_exception//boost_throw_exception
     <library>//boost/variant2//boost_variant2
-    <library>/openssl//openssl
+    <library>/openssl//ssl
+    <library>/openssl//crypto
     ;
 
 compile any_address.cpp ;

--- a/test/standalone/Jamfile
+++ b/test/standalone/Jamfile
@@ -8,7 +8,25 @@
 # import compile rule
 import testing ;
 
-project : requirements <include>../../include ;
+project : requirements
+    <include>../../include
+    <library>//boost/asio//boost_asio
+    <library>//boost/assert//boost_assert
+    <library>//boost/charconv//boost_charconv
+    <library>//boost/compat//boost_compat
+    <library>//boost/container//boost_container
+    <library>//boost/core//boost_core
+    <library>//boost/describe//boost_describe
+    <library>//boost/endian//boost_endian
+    <library>//boost/intrusive//boost_intrusive
+    <library>//boost/mp11//boost_mp11
+    <library>//boost/optional//boost_optional
+    <library>//boost/pfr//boost_pfr
+    <library>//boost/system//boost_system
+    <library>//boost/throw_exception//boost_throw_exception
+    <library>//boost/variant2//boost_variant2
+    <library>/openssl//openssl
+    ;
 
 compile any_address.cpp ;
 compile any_connection.cpp ;

--- a/test/standalone/Jamfile
+++ b/test/standalone/Jamfile
@@ -6,6 +6,7 @@
 #
 
 import testing : compile ;
+import ac ;
 
 project : requirements
     <library>/boost/mysql//boost_mysql

--- a/test/standalone/Jamfile
+++ b/test/standalone/Jamfile
@@ -6,44 +6,8 @@
 #
 
 import testing : compile ;
-import ac ;
-import indirect ;
 
-rule do_fail_impl ( a * )
-{
-    exit "OpenSSL could not be found. Don't build target fail_if_no_openssl to skip this check" ;
-}
-
-local do_fail = [ indirect.make do_fail_impl ] ;
-
-alias fail_if_no_openssl
-    : requirements
-        [ ac.check-library /openssl//ssl    : : <conditional>@$(do_fail) ]
-        [ ac.check-library /openssl//crypto : : <conditional>@$(do_fail) ]
-;
-
-explicit fail_if_no_openssl ;
-
-project : requirements
-    <include>../../include
-    <library>/boost/asio//boost_asio
-    <library>/boost/assert//boost_assert
-    <library>/boost/charconv//boost_charconv
-    <library>/boost/compat//boost_compat
-    <library>/boost/container//boost_container
-    <library>/boost/core//boost_core
-    <library>/boost/describe//boost_describe
-    <library>/boost/endian//boost_endian
-    <library>/boost/intrusive//boost_intrusive
-    <library>/boost/mp11//boost_mp11
-    <library>/boost/optional//boost_optional
-    <library>/boost/pfr//boost_pfr
-    <library>/boost/system//boost_system
-    <library>/boost/throw_exception//boost_throw_exception
-    <library>/boost/variant2//boost_variant2
-    [ ac.check-library /openssl//ssl    : <library>/openssl//ssl/<link>shared : <build>no ]
-    [ ac.check-library /openssl//crypto : <library>/openssl//crypto/<link>shared : <build>no ]
-    ;
+project : requirements <library>/boost/mysql//boost_mysql ;
 
 compile any_address.cpp ;
 compile any_connection.cpp ;

--- a/test/standalone/Jamfile
+++ b/test/standalone/Jamfile
@@ -10,21 +10,21 @@ import testing ;
 
 project : requirements
     <include>../../include
-    <library>//boost/asio//boost_asio
-    <library>//boost/assert//boost_assert
-    <library>//boost/charconv//boost_charconv
-    <library>//boost/compat//boost_compat
-    <library>//boost/container//boost_container
-    <library>//boost/core//boost_core
-    <library>//boost/describe//boost_describe
-    <library>//boost/endian//boost_endian
-    <library>//boost/intrusive//boost_intrusive
-    <library>//boost/mp11//boost_mp11
-    <library>//boost/optional//boost_optional
-    <library>//boost/pfr//boost_pfr
-    <library>//boost/system//boost_system
-    <library>//boost/throw_exception//boost_throw_exception
-    <library>//boost/variant2//boost_variant2
+    <library>/boost/asio//boost_asio
+    <library>/boost/assert//boost_assert
+    <library>/boost/charconv//boost_charconv
+    <library>/boost/compat//boost_compat
+    <library>/boost/container//boost_container
+    <library>/boost/core//boost_core
+    <library>/boost/describe//boost_describe
+    <library>/boost/endian//boost_endian
+    <library>/boost/intrusive//boost_intrusive
+    <library>/boost/mp11//boost_mp11
+    <library>/boost/optional//boost_optional
+    <library>/boost/pfr//boost_pfr
+    <library>/boost/system//boost_system
+    <library>/boost/throw_exception//boost_throw_exception
+    <library>/boost/variant2//boost_variant2
     <library>/openssl//ssl
     <library>/openssl//crypto
     ;

--- a/test/standalone/any_address.cpp
+++ b/test/standalone/any_address.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/any_address.hpp>

--- a/test/standalone/any_connection.cpp
+++ b/test/standalone/any_connection.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/any_connection.hpp>

--- a/test/standalone/bad_field_access.cpp
+++ b/test/standalone/bad_field_access.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/bad_field_access.hpp>

--- a/test/standalone/blob.cpp
+++ b/test/standalone/blob.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/blob.hpp>

--- a/test/standalone/blob_view.cpp
+++ b/test/standalone/blob_view.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/blob_view.hpp>

--- a/test/standalone/buffer_params.cpp
+++ b/test/standalone/buffer_params.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/buffer_params.hpp>

--- a/test/standalone/character_set.cpp
+++ b/test/standalone/character_set.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/character_set.hpp>

--- a/test/standalone/client_errc.cpp
+++ b/test/standalone/client_errc.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/client_errc.hpp>

--- a/test/standalone/column_type.cpp
+++ b/test/standalone/column_type.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/column_type.hpp>

--- a/test/standalone/common_server_errc.cpp
+++ b/test/standalone/common_server_errc.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/common_server_errc.hpp>

--- a/test/standalone/connect_params.cpp
+++ b/test/standalone/connect_params.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/connect_params.hpp>

--- a/test/standalone/connection.cpp
+++ b/test/standalone/connection.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/connection.hpp>

--- a/test/standalone/connection_pool.cpp
+++ b/test/standalone/connection_pool.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/connection_pool.hpp>

--- a/test/standalone/constant_string_view.cpp
+++ b/test/standalone/constant_string_view.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/constant_string_view.hpp>

--- a/test/standalone/date.cpp
+++ b/test/standalone/date.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/date.hpp>

--- a/test/standalone/datetime.cpp
+++ b/test/standalone/datetime.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/datetime.hpp>

--- a/test/standalone/days.cpp
+++ b/test/standalone/days.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/days.hpp>

--- a/test/standalone/defaults.cpp
+++ b/test/standalone/defaults.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/defaults.hpp>

--- a/test/standalone/diagnostics.cpp
+++ b/test/standalone/diagnostics.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/diagnostics.hpp>

--- a/test/standalone/error_categories.cpp
+++ b/test/standalone/error_categories.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/error_categories.hpp>

--- a/test/standalone/error_code.cpp
+++ b/test/standalone/error_code.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/error_code.hpp>

--- a/test/standalone/error_with_diagnostics.cpp
+++ b/test/standalone/error_with_diagnostics.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/error_with_diagnostics.hpp>

--- a/test/standalone/escape_string.cpp
+++ b/test/standalone/escape_string.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/escape_string.hpp>

--- a/test/standalone/execution_state.cpp
+++ b/test/standalone/execution_state.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/execution_state.hpp>

--- a/test/standalone/field.cpp
+++ b/test/standalone/field.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/field.hpp>

--- a/test/standalone/field_kind.cpp
+++ b/test/standalone/field_kind.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/field_kind.hpp>

--- a/test/standalone/field_view.cpp
+++ b/test/standalone/field_view.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/field_view.hpp>

--- a/test/standalone/format_sql.cpp
+++ b/test/standalone/format_sql.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/format_sql.hpp>

--- a/test/standalone/handshake_params.cpp
+++ b/test/standalone/handshake_params.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/handshake_params.hpp>

--- a/test/standalone/is_fatal_error.cpp
+++ b/test/standalone/is_fatal_error.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/is_fatal_error.hpp>

--- a/test/standalone/mariadb_collations.cpp
+++ b/test/standalone/mariadb_collations.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/mariadb_collations.hpp>

--- a/test/standalone/mariadb_server_errc.cpp
+++ b/test/standalone/mariadb_server_errc.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/mariadb_server_errc.hpp>

--- a/test/standalone/metadata.cpp
+++ b/test/standalone/metadata.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/metadata.hpp>

--- a/test/standalone/metadata_collection_view.cpp
+++ b/test/standalone/metadata_collection_view.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/metadata_collection_view.hpp>

--- a/test/standalone/metadata_mode.cpp
+++ b/test/standalone/metadata_mode.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/metadata_mode.hpp>

--- a/test/standalone/mysql_collations.cpp
+++ b/test/standalone/mysql_collations.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/mysql_collations.hpp>

--- a/test/standalone/mysql_server_errc.cpp
+++ b/test/standalone/mysql_server_errc.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/mysql_server_errc.hpp>

--- a/test/standalone/pfr.cpp
+++ b/test/standalone/pfr.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/pfr.hpp>

--- a/test/standalone/pipeline.cpp
+++ b/test/standalone/pipeline.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/pipeline.hpp>

--- a/test/standalone/pool_params.cpp
+++ b/test/standalone/pool_params.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/pool_params.hpp>

--- a/test/standalone/results.cpp
+++ b/test/standalone/results.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/results.hpp>

--- a/test/standalone/resultset.cpp
+++ b/test/standalone/resultset.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/resultset.hpp>

--- a/test/standalone/resultset_view.cpp
+++ b/test/standalone/resultset_view.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/resultset_view.hpp>

--- a/test/standalone/row.cpp
+++ b/test/standalone/row.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/row.hpp>

--- a/test/standalone/row_view.cpp
+++ b/test/standalone/row_view.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/row_view.hpp>

--- a/test/standalone/rows.cpp
+++ b/test/standalone/rows.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/rows.hpp>

--- a/test/standalone/rows_view.cpp
+++ b/test/standalone/rows_view.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/rows_view.hpp>

--- a/test/standalone/sequence.cpp
+++ b/test/standalone/sequence.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/sequence.hpp>

--- a/test/standalone/ssl_mode.cpp
+++ b/test/standalone/ssl_mode.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/ssl_mode.hpp>

--- a/test/standalone/statement.cpp
+++ b/test/standalone/statement.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/statement.hpp>

--- a/test/standalone/static_execution_state.cpp
+++ b/test/standalone/static_execution_state.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/static_execution_state.hpp>

--- a/test/standalone/static_results.cpp
+++ b/test/standalone/static_results.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/static_results.hpp>

--- a/test/standalone/string_view.cpp
+++ b/test/standalone/string_view.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/string_view.hpp>

--- a/test/standalone/tcp.cpp
+++ b/test/standalone/tcp.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/tcp.hpp>

--- a/test/standalone/tcp_ssl.cpp
+++ b/test/standalone/tcp_ssl.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/tcp_ssl.hpp>

--- a/test/standalone/throw_on_error.cpp
+++ b/test/standalone/throw_on_error.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/throw_on_error.hpp>

--- a/test/standalone/time.cpp
+++ b/test/standalone/time.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/time.hpp>

--- a/test/standalone/underlying_row.cpp
+++ b/test/standalone/underlying_row.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/underlying_row.hpp>

--- a/test/standalone/unix.cpp
+++ b/test/standalone/unix.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/unix.hpp>

--- a/test/standalone/unix_ssl.cpp
+++ b/test/standalone/unix_ssl.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/unix_ssl.hpp>

--- a/test/standalone/with_diagnostics.cpp
+++ b/test/standalone/with_diagnostics.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/with_diagnostics.hpp>

--- a/test/standalone/with_params.cpp
+++ b/test/standalone/with_params.cpp
@@ -1,0 +1,8 @@
+//
+// Copyright (c) 2026 Vladislav Soulgard (vsoulgard at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/mysql/with_params.hpp>


### PR DESCRIPTION
close #479 

Added standalone compile tests for all public headers as new build target except src.hpp, because it already compiled separetely in other test target.